### PR TITLE
Not escaped / in filename for the ability to specify directories

### DIFF
--- a/app/obsidian/src/services/template/utils.ts
+++ b/app/obsidian/src/services/template/utils.ts
@@ -62,8 +62,11 @@ export const fileLink = (
     return embed.replace(/^!/, "");
   }
 };
-export const renderFilename = (name: string): string =>
-  filenamify(name, { replacement: "_" });
+export const renderFilename = (path: string): string =>
+  path
+    .split("/")
+    .map((name) => filenamify(name, { replacement: "_" }))
+    .join("/");
 
 export const isImageAnnot = (item: unknown): item is AnnotationInfo =>
   isAnnotationItem(item) && item.type === AnnotationType.image;


### PR DESCRIPTION
Hello!
I'm trying to sync Zotero and Obsidian, so I decided to give your project a try. Thanks for developing it!

However, personally, I found the lack of the ability to create directories according to a template. Issue #207 showed that I'm not alone in this. Code exploration suggested that this could be achieved with minimal changes. So, I decided to create this pull request (PR).

P.S.

I had never dealt with `rushjs` before. So, in the end, exploring and modifying the code took 10 minutes, but the build took 2 and a half hours for some reason! It seemed like I was missing some packages. I don't know how much value my observations on this matter hold for you. But for example, I had to do this:
```
rush add -p esbuild-sass-plugin
rush add -p @preact/signals-core
```
And something wrong with `ophidian-lib-core` submodule. 

At the end I was not able to run the production build as well, but I'm currently using the development build.

P.P.S.

Yes, I saw that [you mentioned](https://github.com/PKM-er/obsidian-zotlit/discussions/240#discussioncomment-7624976) it's not simple and that's indeed true :)