### PR TITLE
Bulk create/update

### DIFF
--- a/app/obsidian/src/note-feature/protocol/service.ts
+++ b/app/obsidian/src/note-feature/protocol/service.ts
@@ -56,19 +56,17 @@ export class ProtocolHandler extends Service {
     if (query.items.length < 1) {
       new Notice("No items to open");
     } else if (query.items.length > 1) {
-      new Notice("Multiple items not yet supported");
+      new Notice("Multiple items in beta");
     }
-    const { libraryID, id } = query.items[0];
-    const [docItem] = await this.plugin.databaseAPI.getItems([[id, libraryID]]);
-    if (!docItem) {
-      new Notice("Item not found: " + id);
-      return;
-    }
-    const notePath = await this.plugin.noteFeatures.createNoteForDocItemFull(
-      docItem,
-    );
-    await this.plugin.app.workspace.openLinkText(notePath, "", false, {
-      active: true,
+    query.items.forEach(({ libraryID, id }) => {
+      this.plugin.databaseAPI.getItems([[id, libraryID]])
+        .then(([docItem]) => {
+          if (!docItem) {
+            new Notice("Item not found: " + id);
+          } else {
+            this.plugin.noteFeatures.createNoteForDocItemFull(docItem);
+          }
+        });
     });
   }
 }

--- a/app/obsidian/src/note-feature/service.ts
+++ b/app/obsidian/src/note-feature/service.ts
@@ -226,8 +226,8 @@ class NoteFeatures extends Service {
 
     const info = noteIndex.getNotesFor(docItem);
     if (info.length) {
-      // only throw error if the note is linked to the same zotero item
-      throw new NoteExistsError(info, docItem.key);
+      // Just update this, why not?
+      return await this.updateNote(info, docItem.key);
     }
 
     const { vault, fileManager } = this.plugin.app,


### PR DESCRIPTION
This is just a draft to get a really important feature addressed. It should close #246 and possibly resolves #269 as well.

I propose two things:
- Simply loop through the items provided by Zotero and iterate over their creation. I removed the call to open the created notes, since that could get excessive.
- Since highlighting multiple documents in Zotero only provides the "Create Literature Note(s)" option, simply allow this option to update notes that already exist. Typically I like to have everything call an `update` function, and then forward the request to `create` if the item doesn't exist, but the reverse should do fine.

Doing a bulk import with these changes does still trigger the Obsidian menu to choose attachments for some of the items, but I feel like this is unavoidable and any assumptions made during import could be the wrong ones, so this part of #269 might be unavoidable.

I tried not to touch too many files, since this is all reverse-engineered from the Obsidian console. I would be happy to add/improve these changes, but I'd need some tips on building the repository.