### PR TITLE
Allow for full dates

### DIFF
--- a/lib/db-worker/src/modules/item-builder.ts
+++ b/lib/db-worker/src/modules/item-builder.ts
@@ -55,7 +55,7 @@ export default class ItemBuilder {
       const fields = itemFields[itemID].reduce((fields, field) => {
         let { value } = field;
         if (field.fieldName === "date") {
-          value = multipartToSQL(value as string).split("-")[0];
+          value = multipartToSQL(value as string);
         }
         (fields[field.fieldName] ??= []).push(value);
         return fields;


### PR DESCRIPTION
See [this comment](https://github.com/PKM-er/obsidian-zotlit/issues/265#issuecomment-1832186320) for how to find this fix and replace it in the Obsidian plugin.

This _should_ close #202 and close #265 as well. Omitting this splitting actually lets the field be parsed correctly into a full date which Obsidian has no problem parsing on its own.

Please let me know if there's anything else that should be considered for this and I'd be happy to add it.