### PR TITLE
fix: support Zotero 8 and stabilize citationKey handling

### DIFF
--- a/app/obsidian/src/note-feature/citation-suggest/basic.ts
+++ b/app/obsidian/src/note-feature/citation-suggest/basic.ts
@@ -1,6 +1,6 @@
 import type { AttachmentInfo, RegularItemInfo } from "@obzt/database";
 import type { EditorSuggestContext, TFile } from "obsidian";
-import { Keymap } from "obsidian";
+import { Keymap, Notice } from "obsidian";
 import {
   cacheAttachmentSelect,
   chooseAnnotAtch,
@@ -23,9 +23,26 @@ export async function insertCitation(
 ) {
   const { plugin } = template;
   const libId = plugin.settings.libId;
+  let docItem = item;
+
+  // Search results come from the in-memory index; refresh once if citekey is stale.
+  if (!docItem.citekey) {
+    const [freshItem] = await plugin.databaseAPI.getItems(
+      [[item.itemID, libId]],
+      true,
+    );
+    if (freshItem) {
+      docItem = freshItem;
+    }
+  }
+
+  if (!docItem.citekey) {
+    new Notice("Selected item has no citekey/citationKey in Zotero.");
+    return;
+  }
 
   const allAttachments = await plugin.databaseAPI.getAttachments(
-    item.itemID,
+    docItem.itemID,
     libId,
   );
 
@@ -46,10 +63,10 @@ export async function insertCitation(
   }
 
   const notes = await plugin.databaseAPI
-    .getNotes(item.itemID, libId)
+    .getNotes(docItem.itemID, libId)
     .then((notes) => plugin.noteParser.normalizeNotes(notes));
   const extraByAtch = await getHelperExtraByAtch(
-    item,
+    docItem,
     { all: allAttachments, selected: allSelectedAtchs, notes },
     template.plugin,
   );

--- a/app/obsidian/src/note-feature/protocol/service.ts
+++ b/app/obsidian/src/note-feature/protocol/service.ts
@@ -18,7 +18,7 @@ export class ProtocolHandler extends Service {
     );
     this.registerEvent(
       this.plugin.server.on("zotero/update", (p) =>
-        this.onZtExport(parseQuery(p)),
+        this.onZtUpdate(parseQuery(p)),
       ),
     );
   }
@@ -55,8 +55,11 @@ export class ProtocolHandler extends Service {
     }
     if (query.items.length < 1) {
       new Notice("No items to open");
-    } else if (query.items.length > 1) {
+      return;
+    }
+    if (query.items.length > 1) {
       new Notice("Multiple items not yet supported");
+      return;
     }
     const { libraryID, id } = query.items[0];
     const [docItem] = await this.plugin.databaseAPI.getItems([[id, libraryID]]);

--- a/app/obsidian/src/note-feature/template-preview/base.ts
+++ b/app/obsidian/src/note-feature/template-preview/base.ts
@@ -134,31 +134,39 @@ export function asyncDebounce<T extends unknown[], V>(
   timeout?: number,
 ): (...args: [...T]) => void {
   let timeoutId: number | null = null;
-  let pending: Promise<any> | null = null;
+  let running = false;
+  let queuedArgs: [...T] | null = null;
 
-  let taskDuringPending: [...T] | null = null;
+  const run = async (args: [...T]) => {
+    running = true;
+    try {
+      await cb(...args);
+    } catch (error) {
+      console.error(error);
+    }
+    while (queuedArgs) {
+      const nextArgs = queuedArgs;
+      queuedArgs = null;
+      try {
+        await cb(...nextArgs);
+      } catch (error) {
+        console.error(error);
+      }
+    }
+    running = false;
+  };
+
   return function (...args) {
     if (timeoutId) {
       window.clearTimeout(timeoutId);
     }
-    if (pending) {
-      taskDuringPending = args;
+    if (running) {
+      queuedArgs = args;
       return;
     }
     timeoutId = window.setTimeout(() => {
       timeoutId = null;
-      pending = cb(...args)
-        .then(() => {
-          if (taskDuringPending) {
-            pending = cb(...taskDuringPending);
-          } else {
-            pending = null;
-          }
-        })
-        .catch((error) => {
-          console.error(error);
-          pending = null;
-        });
+      void run(args);
     }, timeout);
   };
 }

--- a/app/obsidian/src/note-feature/template-preview/open.ts
+++ b/app/obsidian/src/note-feature/template-preview/open.ts
@@ -1,4 +1,4 @@
-import type { App } from "obsidian";
+import type { App, WorkspaceLeaf } from "obsidian";
 import { MarkdownView, Notice, TFile } from "obsidian";
 import { fromPath, toPath, type TplType } from "@/services/template/eta/preset";
 import type { SettingsService } from "@/settings/base";
@@ -18,14 +18,17 @@ export async function openTemplatePreview(
     new Notice("Template file not found: " + type);
     return;
   }
-  const existing = workspace.getLeavesOfType("markdown").filter((l) => {
-    const view = l.view as MarkdownView;
-    if (!view.file) return false;
-    return (
+  const existing: WorkspaceLeaf[] = [];
+  for (const leaf of workspace.getLeavesOfType("markdown")) {
+    const view = await ensureMarkdownView(leaf);
+    if (!view?.file) continue;
+    if (
       fromPath(view.file.path, settings.templateDir)?.type === "ejectable" &&
-      l.getRoot().type === "floating"
-    );
-  });
+      leaf.getRoot().type === "floating"
+    ) {
+      existing.push(leaf);
+    }
+  }
 
   if (existing.length > 0) {
     const markdown = existing[0];
@@ -33,7 +36,8 @@ export async function openTemplatePreview(
     if (!markdown.group) return;
     const inGroup = workspace.getGroupLeaves(markdown.group);
     for (const leaf of inGroup) {
-      const viewType = leaf.view.getViewType();
+      await loadLeafIfDeferred(leaf);
+      const viewType = leaf.getViewState().type;
       if (
         viewType === templatePreviewViewType ||
         viewType === itemDetailsViewType
@@ -79,15 +83,31 @@ export function getTemplateFile(
   return null;
 }
 
-export function getTemplateEditorInGroup(group: string, plugin: ZoteroPlugin) {
-  const templateEditorLeaf = plugin.app.workspace
-    .getGroupLeaves(group)
-    .find(
-      (l) =>
-        l.view instanceof MarkdownView &&
-        l.view.file &&
-        fromPath(l.view.file.path, plugin.settings.templateDir)?.type ===
-          "ejectable",
-    );
-  return templateEditorLeaf;
+export async function getTemplateEditorInGroup(
+  group: string,
+  plugin: ZoteroPlugin,
+) {
+  for (const leaf of plugin.app.workspace.getGroupLeaves(group)) {
+    const view = await ensureMarkdownView(leaf);
+    if (
+      view?.file &&
+      fromPath(view.file.path, plugin.settings.templateDir)?.type ===
+        "ejectable"
+    ) {
+      return leaf;
+    }
+  }
+  return undefined;
+}
+
+async function ensureMarkdownView(leaf: WorkspaceLeaf) {
+  await loadLeafIfDeferred(leaf);
+  return leaf.view instanceof MarkdownView ? leaf.view : null;
+}
+
+async function loadLeafIfDeferred(leaf: WorkspaceLeaf) {
+  const loadIfDeferred = (leaf as WorkspaceLeaf & {
+    loadIfDeferred?: () => Promise<void>;
+  }).loadIfDeferred;
+  await loadIfDeferred?.();
 }

--- a/app/obsidian/src/note-feature/template-preview/preview.ts
+++ b/app/obsidian/src/note-feature/template-preview/preview.ts
@@ -20,7 +20,7 @@ export class TemplatePreview extends TemplatePreviewBase {
 
   async switchToTemplate(type: TplType.Ejectable) {
     if (!this.leaf.group) return false;
-    const templateEditorLeaf = getTemplateEditorInGroup(
+    const templateEditorLeaf = await getTemplateEditorInGroup(
       this.leaf.group,
       this.plugin,
     );

--- a/app/obsidian/src/services/citekey-click/service.ts
+++ b/app/obsidian/src/services/citekey-click/service.ts
@@ -3,11 +3,11 @@ import { Service } from "@ophidian/core";
 import { around } from "monkey-around";
 import type {
   Editor,
-  MarkdownView,
   EditorPosition,
   MarkdownEditView,
+  WorkspaceLeaf,
 } from "obsidian";
-import { Notice } from "obsidian";
+import { MarkdownView, Notice } from "obsidian";
 
 import { untilWorkspaceReady, waitUntil } from "@/utils/once";
 import ZoteroPlugin from "@/zt-main";
@@ -45,8 +45,11 @@ export class CitekeyClick extends Service {
     cancel && this.register(cancel);
     await task;
 
-    const mdView = workspace.getLeavesOfType("markdown")[0]!
-      .view as MarkdownView;
+    const mdView = await getFirstLoadedMarkdownView(workspace);
+    if (!mdView) {
+      new Notice("No markdown editor available for citekey click support");
+      return;
+    }
 
     this.register(
       around(mdView.editor.constructor.prototype as Editor, {
@@ -92,6 +95,28 @@ export class CitekeyClick extends Service {
       }),
     );
   }
+}
+
+async function getFirstLoadedMarkdownView(
+  workspace: ZoteroPlugin["app"]["workspace"],
+) {
+  for (const leaf of workspace.getLeavesOfType("markdown")) {
+    const view = await ensureMarkdownView(leaf);
+    if (view) {
+      return view;
+    }
+  }
+  return null;
+}
+
+async function ensureMarkdownView(leaf: WorkspaceLeaf) {
+  const loadIfDeferred = (leaf as WorkspaceLeaf & {
+    loadIfDeferred?: () => Promise<void>;
+  }).loadIfDeferred;
+  if (!(leaf.view instanceof MarkdownView)) {
+    await loadIfDeferred?.();
+  }
+  return leaf.view instanceof MarkdownView ? leaf.view : null;
 }
 
 function getClickableTokenAt(

--- a/app/obsidian/src/services/server/service.ts
+++ b/app/obsidian/src/services/server/service.ts
@@ -129,22 +129,17 @@ export class Server extends Service implements Events {
       event = `bg:${pathname.substring(1)}`;
     if (bgActions.has(action)) {
       const params = Object.fromEntries(searchParams.entries());
-      if (request.headers["content-type"] === "application/json") {
-        new Promise<unknown>((resolve, reject) => {
-          let data = "";
-          request.on("data", (chunk) => (data += chunk));
-          request.on("error", (error) => reject(error));
-          request.on("end", () => {
-            try {
-              resolve(JSON.parse(data));
-            } catch (error) {
-              reject(error);
-            }
+      if (isJsonRequest(request)) {
+        void readJsonBody(request)
+          .then((data) => {
+            this.trigger(event, params, data);
+            response.end();
+          })
+          .catch((error) => {
+            log.error(`Failed to process ${action} request`, error);
+            response.statusCode = 400;
+            response.end();
           });
-        }).then((data) => {
-          this.trigger(event, params, data);
-          response.end();
-        });
       } else {
         this.trigger(event, params);
         response.end();
@@ -205,4 +200,28 @@ function logAddr(server: HTTPServer) {
   if (!addr) return "?";
   if (typeof addr === "string") return addr;
   return `${addr.address}:${addr.port}`;
+}
+
+function isJsonRequest(request: IncomingMessage) {
+  const contentType = request.headers["content-type"];
+  if (!contentType) return false;
+  const values = Array.isArray(contentType) ? contentType : [contentType];
+  return values.some((value) =>
+    value.toLowerCase().startsWith("application/json"),
+  );
+}
+
+function readJsonBody(request: IncomingMessage) {
+  return new Promise<unknown>((resolve, reject) => {
+    let data = "";
+    request.on("data", (chunk) => (data += chunk));
+    request.on("error", (error) => reject(error));
+    request.on("end", () => {
+      try {
+        resolve(JSON.parse(data));
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
 }

--- a/app/obsidian/src/services/template/defaults/zt-cite.ejs
+++ b/app/obsidian/src/services/template/defaults/zt-cite.ejs
@@ -1,1 +1,1 @@
-[<%= it.map(lit => `@${lit.citekey}`).join("; ") %>]
+[<%= it.filter(lit => !!lit.citekey).map(lit => `@${lit.citekey}`).join("; ") %>]

--- a/app/obsidian/src/services/template/defaults/zt-cite2.ejs
+++ b/app/obsidian/src/services/template/defaults/zt-cite2.ejs
@@ -1,1 +1,1 @@
-<%= it.map(lit => `@${lit.citekey}`).join("; ") %>
+<%= it.filter(lit => !!lit.citekey).map(lit => `@${lit.citekey}`).join("; ") %>

--- a/app/obsidian/src/services/zotero-db/auto-refresh/service.ts
+++ b/app/obsidian/src/services/zotero-db/auto-refresh/service.ts
@@ -66,7 +66,7 @@ export default class DatabaseWatcher extends Service {
         this.#watcher.bbt = watch(
           loadStatus.bbtVersion === "v0"
             ? this.settings.bbtSearchDbPath
-            : this.settings.bbtMainDbPath,
+            : this.settings.zoteroDbPath,
           this.onDatabaseUpdate("bbt"),
         );
       }

--- a/app/obsidian/src/setting-tab/components/Setting.tsx
+++ b/app/obsidian/src/setting-tab/components/Setting.tsx
@@ -1,6 +1,5 @@
 import { cn } from "@obzt/components/utils";
-// import { computed, effect } from "@ophidian/core";
-import { computed } from "@preact/signals-core";
+import { computed } from "@ophidian/core";
 import { useMemoizedFn } from "ahooks";
 import type { PropsWithChildren, ReactNode } from "react";
 import { forwardRef, useContext, useMemo, useRef } from "react";
@@ -48,7 +47,7 @@ export function useSetting<T>(
   set: (val: T, settings: Settings) => Settings,
 ) {
   const service = useContext(SettingTabCtx).settings;
-  const value = useComputed(() => get(service.current)).value;
+  const value = useComputed(() => get(service.current))();
   const onChange = useMemoizedFn(function onChange(val: T) {
     service.update((prev) => set(val, prev));
   });

--- a/app/obsidian/src/setting-tab/connect/Database.tsx
+++ b/app/obsidian/src/setting-tab/connect/Database.tsx
@@ -9,11 +9,15 @@ import type { DatabaseStatus } from "./useDatabaseStatus";
 import { useDatabaseStatus } from "./useDatabaseStatus";
 
 export default function DatabaseSetting() {
+  const { settings } = useContext(SettingTabCtx);
   const mainDbPath = useDatabasePath("main");
-  const bbtDbPath = useDatabasePath("bbt");
+  const [bbtDbStatus, refreshBbtDb, bbtInfo] = useDatabaseStatus("bbt");
+  const bbtDbPath =
+    bbtInfo?.bbtVersion === "v1"
+      ? `${settings.zoteroDbPath} (native citationKey field)`
+      : settings.bbtMainDbPath;
 
   const [mainDbStatus, refreshMainDb] = useDatabaseStatus("zotero");
-  const [bbtDbStatus, refreshBbtDb] = useDatabaseStatus("bbt");
 
   const [dataDir, dataDirState, setDataDir] = useApplyDataDir(() => {
     refreshMainDb();

--- a/app/obsidian/src/setting-tab/connect/useDatabaseStatus.tsx
+++ b/app/obsidian/src/setting-tab/connect/useDatabaseStatus.tsx
@@ -4,10 +4,7 @@ import { SettingTabCtx, useRefreshAsync } from "../common";
 export function useDatabaseStatus(target: "zotero" | "bbt") {
   const { database } = useContext(SettingTabCtx);
   const [promise, refresh] = useRefreshAsync(
-    () =>
-      database.api
-        .getLoadStatus()
-        .then((s) => (target === "zotero" ? s.main : s.bbt)),
+    () => database.api.getLoadStatus(),
     [target],
   );
 
@@ -17,8 +14,15 @@ export function useDatabaseStatus(target: "zotero" | "bbt") {
   } else if (promise.error) {
     state = "failed";
   } else {
-    state = promise.result ? "success" : "failed";
+    state =
+      target === "zotero"
+        ? promise.result?.main
+          ? "success"
+          : "failed"
+        : promise.result?.bbt
+        ? "success"
+        : "failed";
   }
-  return [state, refresh] as const;
+  return [state, refresh, promise.result] as const;
 }
 export type DatabaseStatus = "success" | "failed" | "disabled";

--- a/app/obsidian/src/settings/base.ts
+++ b/app/obsidian/src/settings/base.ts
@@ -1,6 +1,6 @@
 import { join } from "path";
 import type { DatabaseOptions, DatabasePaths } from "@obzt/database/api";
-import type { Useful } from "@ophidian/core";
+import type { OptionalCleanup, Useful } from "@ophidian/core";
 import {
   calc,
   SettingsService as _SettingsService,
@@ -11,16 +11,42 @@ import { getBinaryFullPath } from "@/install-guide/version";
 import ZoteroPlugin from "@/zt-main";
 import { getDefaultSettings, type Settings } from "./service";
 
-export function skip<T extends (...args: any[]) => any>(
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "then" in value &&
+    typeof (value as PromiseLike<unknown>).then === "function"
+  );
+}
+
+export function skip<T extends (...args: any[]) => OptionalCleanup>(
+  compute: T,
+  deps: () => any,
+  skipInitial?: boolean,
+): (...args: Parameters<T>) => ReturnType<T> | undefined;
+export function skip<T extends (...args: any[]) => PromiseLike<unknown>>(
+  compute: T,
+  deps: () => any,
+  skipInitial?: boolean,
+): (...args: Parameters<T>) => void;
+export function skip<T extends (...args: any[]) => OptionalCleanup | PromiseLike<unknown>>(
   compute: T,
   deps: () => any,
   skipInitial = false,
 ) {
   let count = 0;
-  return (...args: Parameters<T>): ReturnType<T> | undefined => {
+  return (...args: Parameters<T>) => {
     deps();
     if (count++ > (skipInitial ? 1 : 0)) {
-      return compute(...args);
+      const result = compute(...args);
+      if (isPromiseLike(result)) {
+        void Promise.resolve(result).catch((error: unknown) => {
+          console.error("Unhandled async effect in skip()", error);
+        });
+        return;
+      }
+      return result;
     }
   };
 }

--- a/app/obsidian/src/zt-main.ts
+++ b/app/obsidian/src/zt-main.ts
@@ -33,8 +33,10 @@ declare global {
   var zoteroAPI: PluginAPI | undefined;
 }
 
+type PluginContextOwner = Parameters<typeof use.plugin>[0];
+
 export default class ZoteroPlugin extends Plugin {
-  use = use.plugin(this);
+  use = use.plugin(this as unknown as PluginContextOwner);
 
   constructor(app: App, manifest: PluginManifest) {
     super(app, manifest);

--- a/lib/database/src/sql/bibtex/get-citekey.ts
+++ b/lib/database/src/sql/bibtex/get-citekey.ts
@@ -1,7 +1,7 @@
 import type { Transaction } from "better-sqlite3";
 import type { IDLibID } from "../../utils/index.js";
 import { PreparedBase } from "../../utils/index.js";
-import { BBT_MAIN_DB_NAME, BBT_SEARCH_DB_NAME } from "./base.js";
+import { BBT_SEARCH_DB_NAME } from "./base.js";
 
 interface InputSql {
   itemID: number;
@@ -19,12 +19,22 @@ type Output = Record<number, string>;
 
 const sqlMain = `--sql
 SELECT
-  citationkey as citekey
+  itemDataValues.value AS citekey
 FROM
-  ${BBT_MAIN_DB_NAME}.citationkey
+  itemData
+  JOIN itemDataValues USING (valueID)
 WHERE
-  itemID = $itemID
-  AND (libraryID IS NULL OR libraryID = $libId)
+  itemData.itemID = $itemID
+  AND itemData.fieldID = (
+    SELECT
+      fieldID
+    FROM
+      fieldsCombined
+    WHERE
+      fieldName = 'citationKey'
+    LIMIT
+      1
+  )
 `;
 
 const sqlSearch = `--sql

--- a/lib/database/src/sql/bibtex/get-id.ts
+++ b/lib/database/src/sql/bibtex/get-id.ts
@@ -1,14 +1,25 @@
 import type { Transaction } from "better-sqlite3";
 import { PreparedBase } from "../../utils/index.js";
-import { BBT_MAIN_DB_NAME, BBT_SEARCH_DB_NAME } from "./base.js";
+import { BBT_SEARCH_DB_NAME } from "./base.js";
 
 const sqlMain = `--sql
 SELECT
-  itemID
+  itemData.itemID AS itemID
 FROM
-  ${BBT_MAIN_DB_NAME}.citationkey
+  itemData
+  JOIN itemDataValues USING (valueID)
 WHERE
-  citationkey = $citekey
+  itemData.fieldID = (
+    SELECT
+      fieldID
+    FROM
+      fieldsCombined
+    WHERE
+      fieldName = 'citationKey'
+    LIMIT
+      1
+  )
+  AND itemDataValues.value = $citekey
 `;
 
 const sqlSearch = `--sql

--- a/lib/db-worker/src/modules/connections.ts
+++ b/lib/db-worker/src/modules/connections.ts
@@ -22,10 +22,28 @@ function isBBTAfterMigration(db: Database) {
   return db.tableExists("citationkey", BBT_MAIN_DB_NAME);
 }
 
+function hasNativeCitationKeyField(db: Database) {
+  const instance = db.instance;
+  if (
+    !instance ||
+    !db.tableExists("fieldsCombined") ||
+    !db.tableExists("itemData") ||
+    !db.tableExists("itemDataValues")
+  ) {
+    return false;
+  }
+  const result = instance
+    .prepare(
+      `SELECT 1 AS exist FROM fieldsCombined WHERE fieldName = 'citationKey' LIMIT 1`,
+    )
+    .get() as { exist?: number } | undefined;
+  return !!result?.exist;
+}
+
 export default class Connections {
   #instance: {
     zotero: Database;
-    bbtAfterMigration: boolean;
+    citekeyBackend: "unavailable" | "v0" | "v1";
     libraries: Record<number, LibraryInfo>;
   } | null = null;
 
@@ -51,28 +69,28 @@ export default class Connections {
         bbtSearch: null,
       };
     }
-    const loadedDb = this.#instance.zotero.databaseList;
-    const isMainLoaded = loadedDb.some((v) => v.name === BBT_MAIN_DB_NAME);
-    if (!isMainLoaded)
+    if (this.#instance.citekeyBackend === "unavailable") {
       return {
         main: true,
         bbtMain: false,
         bbtSearch: null,
       };
+    }
 
-    // In v6.7.128+, citekeys are stored in main db
-    if (this.#instance.bbtAfterMigration)
+    // In v6.7.128+, citekeys are stored in main db or can be read from
+    // Zotero's native citationKey field without the legacy search database.
+    if (this.#instance.citekeyBackend === "v1")
       return {
         main: true,
         bbtMain: true,
         bbtSearch: null,
       };
-    // Before v6.7.128, the citekeys is stored in dedicated database
-    const isSearchLoaded = loadedDb.some((v) => v.name === BBT_SEARCH_DB_NAME);
+
+    // Before v6.7.128, the citekeys are stored in a dedicated search database.
     return {
       main: true,
       bbtMain: true,
-      bbtSearch: isSearchLoaded,
+      bbtSearch: true,
     };
   }
   get bbtLoadStatus(): boolean {
@@ -85,17 +103,17 @@ export default class Connections {
   getItemIDsFromCitekey(citekeys: string[]) {
     if (!this.#instance) throw new DatabaseNotSetError();
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const BibtexGetId = this.#instance.bbtAfterMigration
-      ? BibtexGetIdV1
-      : BibtexGetIdV0;
+    const BibtexGetId =
+      this.#instance.citekeyBackend === "v0" ? BibtexGetIdV0 : BibtexGetIdV1;
     return this.#instance.zotero.prepare(BibtexGetId).query({ citekeys });
   }
   getCitekeys(items: IDLibID[]) {
     if (!this.#instance) throw new DatabaseNotSetError();
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const BibtexGetCitekey = this.#instance.bbtAfterMigration
-      ? BibtexGetCitekeyV1
-      : BibtexGetCitekeyV0;
+    const BibtexGetCitekey =
+      this.#instance.citekeyBackend === "v0"
+        ? BibtexGetCitekeyV0
+        : BibtexGetCitekeyV1;
     return this.#instance.zotero.prepare(BibtexGetCitekey).query({ items });
   }
 
@@ -122,7 +140,12 @@ export default class Connections {
         );
       this.#instance = {
         ...db,
-        bbtAfterMigration: bbtLoadStatus.bbtSearch === null,
+        citekeyBackend:
+          bbtLoadStatus.bbtMain === false
+            ? "unavailable"
+            : bbtLoadStatus.bbtSearch === true
+              ? "v0"
+              : "v1",
         libraries,
       };
       this.status = "READY";
@@ -147,6 +170,11 @@ type DatabaseStatus = "READY" | "ERROR" | "NOT_INITIALIZED";
 
 function openBetterBibtex(paths: DatabasePaths, db: Database): BBTLoadStatus {
   const bbtMainUri = toSqliteUri(paths.bbtMain);
+  const useNativeCitationKey = () => {
+    if (!hasNativeCitationKeyField(db)) return null;
+    log.debug("Using native Zotero citationKey field");
+    return { bbtMain: true, bbtSearch: null } satisfies BBTLoadStatus;
+  };
   try {
     log.debug(`Attaching bbt main database: ${bbtMainUri}`);
     db.attachDatabase(bbtMainUri, BBT_MAIN_DB_NAME);
@@ -160,6 +188,8 @@ function openBetterBibtex(paths: DatabasePaths, db: Database): BBTLoadStatus {
     } else {
       log.debug(`Unable to open bbt main database, ${code} @ ${bbtMainUri}`);
     }
+    const nativeFallback = useNativeCitationKey();
+    if (nativeFallback) return nativeFallback;
     return { bbtMain: false, bbtSearch: null };
   }
   const isAfterMigration = isBBTAfterMigration(db);
@@ -167,7 +197,7 @@ function openBetterBibtex(paths: DatabasePaths, db: Database): BBTLoadStatus {
   const bbtSearchUri = toSqliteUri(paths.bbtSearch);
   try {
     log.debug(`Attaching bbt search database: ${bbtSearchUri}`);
-    db.attachDatabase(bbtSearchUri, BBT_MAIN_DB_NAME);
+    db.attachDatabase(bbtSearchUri, BBT_SEARCH_DB_NAME);
     log.debug(`Attached bbt search database: ${bbtSearchUri}`);
   } catch (err) {
     const { code } = err as { code: string };
@@ -180,6 +210,8 @@ function openBetterBibtex(paths: DatabasePaths, db: Database): BBTLoadStatus {
         `Unable to open bbt search database, ${code} @ ${bbtSearchUri}`,
       );
     }
+    const nativeFallback = useNativeCitationKey();
+    if (nativeFallback) return nativeFallback;
     return { bbtMain: true, bbtSearch: false };
   }
   return { bbtMain: true, bbtSearch: true };


### PR DESCRIPTION
 ## Summary

  This PR restores compatibility with Zotero 8 and fixes several related regressions in both the Zotero and Obsidian sides of `obsidian-zotlit`.

  It focuses on three areas:

  - Zotero 8 menu and reader API compatibility
  - native `citationKey` / Better BibTeX fallback handling
  - Obsidian-side citation insertion and runtime/build fixes

  ## Changes

  - added Zotero 8-compatible bootstrap fallback via `Services.sys.mjs`
  - updated item menu registration for Zotero 8
  - added MenuManager-based menu support and virtual menu adapters
  - updated reader menu/event hooks to support newer reader internals
  - hardened annotation update logic for changed reader iframe/window fields

  - fixed citekey backend selection in the db worker
  - fixed legacy BBT v0 search DB attachment alias
  - added fallback to Zotero native `citationKey` when BBT DBs are unavailable
  - fixed load status reporting for native citationKey fallback
  - updated Zotero addon compatibility metadata to `strict_max_version: 8.*`

  - fixed Obsidian-side async `effect()` callback issues
  - removed the broken direct dependency on `@preact/signals-core`
  - fixed plugin context typing around `use.plugin(this)`
  - improved template preview and citekey-click behavior for deferred markdown leaves
  - fixed JSON request parsing in the local Obsidian server
  - fixed citation insertion so stale results no longer render `[@undefined]`
  - updated default citation templates to skip missing citekeys instead of rendering `undefined`

  ## Validation

  - `app/zotero` typecheck passed
  - `app/obsidian` typecheck passed
  - `app/obsidian` production build passed
  - verified literature note creation in a live Zotero + Obsidian setup
  - verified citation insertion no longer produces `[@undefined]`

  ## Notes

  This PR contains source-level compatibility fixes only.

  I intentionally left local environment-only changes, temporary test fixtures, and unrelated workspace noise out of this branch.