### PR TITLE
fix(zotero): support Zotero 8 menus and reader APIs

### DIFF
--- a/app/zotero/src/main.ts
+++ b/app/zotero/src/main.ts
@@ -92,43 +92,7 @@ export default class ZoteroPlugin extends Plugin<typeof settings> {
       label: "Obsidian Note",
       image: this.getResourceURL(this.icons[32]),
     });
-    this.registerMenu("item", (menu) =>
-      menu.addSeparator().addSubmenu("Obsidian Actions", (menu) =>
-        menu
-          .addItem((item) =>
-            item
-              .setTitle("Open Literature Note")
-              .onClick(() => this.handleSelectedItems("open"))
-              .onShowing((item) =>
-                item.toggle(
-                  this.app.getActiveZoteroPane().getSelectedItems().length ===
-                    1,
-                ),
-              ),
-          )
-          .addItem((item) =>
-            item
-              .setTitle("Update Literature Note")
-              .onClick(() => this.handleSelectedItems("update"))
-              .onShowing((item) =>
-                item.toggle(
-                  this.app.getActiveZoteroPane().getSelectedItems().length ===
-                    1,
-                ),
-              ),
-          )
-          .addItem((item) =>
-            item
-              .setTitle("Create Literature Note(s)")
-              .onClick(() => this.handleSelectedItems("export"))
-              .onShowing((item) =>
-                item.toggle(
-                  this.app.getActiveZoteroPane().getSelectedItems().length >= 1,
-                ),
-              ),
-          ),
-      ),
-    );
+    this.registerItemMenu();
 
     this.registerMenu("reader:annot", (menu, data, itemID, reader) => {
       const libIdKey = this.app.Items.getLibraryAndKeyFromID(itemID);
@@ -217,6 +181,51 @@ export default class ZoteroPlugin extends Plugin<typeof settings> {
         );
     });
   }
+
+  private getSupportedItems(items?: readonly Zotero.Item[]) {
+    let selected: readonly Zotero.Item[] =
+      items ?? this.app.getActiveZoteroPane().getSelectedItems();
+    if (selected.length === 0) return [];
+    selected = selected
+      .filter(
+        (item: Zotero.Item): boolean =>
+          item.isRegularItem() ||
+          (item.isAttachment() && !!item.parentItem?.isRegularItem()),
+      )
+      .map((item: Zotero.Item) => (item.isAttachment() ? item.parentItem! : item));
+    if (selected.length === 0) return [];
+    return uniqBy(selected, (item) => item.id);
+  }
+
+  private registerItemMenu() {
+    // Zotero 8 MenuManager currently renders blank labels with raw strings here.
+    // Use the native item popup directly until this menu is localized properly.
+    this.registerMenu("#zotero-itemmenu", (menu) =>
+      menu.addSeparator().addSubmenu("Obsidian Actions", (menu) =>
+        menu
+          .addItem((item) =>
+            item
+              .setTitle("Open Literature Note")
+              .onClick(() => this.handleSelectedItems("open"))
+              .onShowing((item) => item.toggle(this.getSupportedItems().length === 1)),
+          )
+          .addItem((item) =>
+            item
+              .setTitle("Update Literature Note")
+              .onClick(() => this.handleSelectedItems("update"))
+              .onShowing((item) => item.toggle(this.getSupportedItems().length === 1)),
+          )
+          .addItem((item) =>
+            item
+              .setTitle("Create Literature Note(s)")
+              .onClick(() => this.handleSelectedItems("export"))
+              .onShowing((item) =>
+                item.toggle(this.getSupportedItems().length >= 1),
+              ),
+          ),
+      ),
+    );
+  }
   onunload(): void {
     this.app.log("zotero-obsidian-note unloaded");
   }
@@ -243,7 +252,9 @@ export default class ZoteroPlugin extends Plugin<typeof settings> {
       const active = [...this.readerFocus.values()].filter((a) => a !== -1);
       const attachmentId = active[active.length - 1] ?? -1;
       if (attachmentId === this.lastActiveReader) return;
-      const itemId = this.app.Items.get(attachmentId).parentItemID;
+      const attachment =
+        attachmentId === -1 ? null : this.app.Items.get(attachmentId);
+      const itemId = attachment?.parentItemID;
       if (typeof itemId !== "number") {
         // prevent notify when reader is not attached to an regular item's attachment
         this.lastActiveReader = attachmentId;
@@ -282,22 +293,8 @@ export default class ZoteroPlugin extends Plugin<typeof settings> {
   }
 
   handleSelectedItems(action: QueryAction) {
-    let items: readonly Zotero.Item[] = this.app
-      .getActiveZoteroPane()
-      .getSelectedItems();
+    let items = this.getSupportedItems();
     if (items.length === 0) return;
-    items = items
-      .filter(
-        (item: Zotero.Item): boolean =>
-          item.isRegularItem() || // !note && !annotation && !attachment
-          (item.isAttachment() && !!item?.parentItem?.isRegularItem()),
-      )
-      // get regular item
-      .map((item: Zotero.Item) =>
-        item.isAttachment() ? item.parentItem! : item,
-      );
-    if (items.length === 0) return;
-    items = uniqBy(items, (i) => i.id);
     this.sendToObsidian("item", action, items);
   }
 

--- a/app/zotero/src/update-annots.ts
+++ b/app/zotero/src/update-annots.ts
@@ -13,9 +13,18 @@ export async function updateAnnotations(
   reader: _ZoteroTypes.ReaderInstance,
   annots: UpdateAnnot[],
 ) {
+  const iframeWindow =
+    (reader as _ZoteroTypes.ReaderInstance & {
+      _iframeWindow?: typeof globalThis | null;
+      _iframe?: { contentWindow?: typeof globalThis | null } | null;
+      _window?: typeof globalThis | null;
+    })._iframeWindow ??
+    (reader as any)._iframe?.contentWindow ??
+    (reader as any)._window ??
+    null;
   await (
-    reader._iframeWindow as any
+    iframeWindow as any
   )?.wrappedJSObject.viewerInstance._viewer._annotationsStore.updateAnnotations(
-    Components.utils.cloneInto(annots, reader._iframeWindow),
+    Components.utils.cloneInto(annots, iframeWindow),
   );
 }

--- a/app/zotero/update.json
+++ b/app/zotero/update.json
@@ -23,7 +23,7 @@
           },
           "zotero": {
             "strict_min_version": "6.999",
-            "strict_max_version": "7.0.*"
+            "strict_max_version": "8.*"
           }
         }
       },
@@ -38,7 +38,7 @@
           },
           "zotero": {
             "strict_min_version": "6.999",
-            "strict_max_version": "7.0.*"
+            "strict_max_version": "8.*"
           }
         }
       }

--- a/lib/zotero-helper/src/builder/manifest.ts
+++ b/lib/zotero-helper/src/builder/manifest.ts
@@ -38,7 +38,7 @@ export function genManifestJson(
         id,
         update_url: update.versions,
         strict_min_version: "6.999",
-        strict_max_version: "7.0.*",
+        strict_max_version: "8.*",
       },
     },
   };

--- a/lib/zotero-helper/src/builder/update.ts
+++ b/lib/zotero-helper/src/builder/update.ts
@@ -20,9 +20,9 @@ export function genUpdateJson(
               strict_min_version: "60.9",
               strict_max_version: "60.9",
             },
-            /** Zotero 7 */ zotero: {
+            /** Zotero 8 */ zotero: {
               strict_min_version: "6.999",
-              strict_max_version: "7.0.*",
+              strict_max_version: "8.*",
             },
           },
         },

--- a/lib/zotero-helper/src/zotero/menu/menu-item.ts
+++ b/lib/zotero-helper/src/zotero/menu/menu-item.ts
@@ -19,19 +19,52 @@ export class MenuItem extends Component {
    */
   constructor(private menu: Menu) {
     super();
-    this.dom = createXULElement(
-      menu.dom.ownerDocument,
-      "menuitem",
-    ) as XUL.MenuItem;
+    if (menu.mode === "dom") {
+      this.dom = createXULElement(
+        menu.dom.ownerDocument,
+        "menuitem",
+      ) as XUL.MenuItem;
+    }
   }
-  dom: XUL.MenuItem;
+  dom?: XUL.MenuItem;
+  #title = "";
+  #icon: string | null = null;
+  #disabled = false;
+  #hidden = false;
+  #onClick?: (evt: MouseEvent | KeyboardEvent) => any;
+  #onShowing: Array<(item: this) => any> = [];
+
+  get title() {
+    return this.#title;
+  }
+
+  get icon() {
+    return this.#icon;
+  }
+
+  get disabled() {
+    return this.#disabled;
+  }
+
+  get hidden() {
+    return this.#hidden;
+  }
+
+  runShowingCallbacks() {
+    this.#onShowing.forEach((callback) => callback(this));
+  }
+
+  runCommand(event: MouseEvent | KeyboardEvent) {
+    return this.#onClick?.(event);
+  }
   /**
    * @public
    */
   setTitle(title: string): this {
+    this.#title = title;
     // set label attribute directly not working in Zotero 6
     // have to use setAttribute
-    this.dom.setAttribute("label", title);
+    this.dom?.setAttribute("label", title);
     return this;
   }
   /**
@@ -39,9 +72,12 @@ export class MenuItem extends Component {
    * @param url - data-uri or resource url to an image. If `null`, the icon is removed.
    */
   setIcon(url: string | null): this {
-    this.dom.classList.toggle("menuitem-iconic", url !== null);
+    this.#icon = url;
+    this.dom?.classList.toggle("menuitem-iconic", url !== null);
     if (url !== null) {
-      this.dom.style.listStyleImage = `url("${url}")`;
+      this.dom?.style.setProperty("list-style-image", `url("${url}")`);
+    } else {
+      this.dom?.style.removeProperty("list-style-image");
     }
     return this;
   }
@@ -50,7 +86,10 @@ export class MenuItem extends Component {
    * @public
    */
   setDisabled(disabled: boolean): this {
-    this.dom.disabled = disabled;
+    this.#disabled = disabled;
+    if (this.dom) {
+      this.dom.disabled = disabled;
+    }
     return this;
   }
 
@@ -61,7 +100,8 @@ export class MenuItem extends Component {
     return this.toggle(false);
   }
   toggle(show: boolean): this {
-    this.dom.setAttribute("hidden", show ? "false" : "true");
+    this.#hidden = !show;
+    this.dom?.setAttribute("hidden", show ? "false" : "true");
     return this;
   }
 
@@ -69,13 +109,19 @@ export class MenuItem extends Component {
    * @public
    */
   onClick(callback: (evt: MouseEvent | KeyboardEvent) => any): this {
-    this.registerDomEvent(this.dom, "command", callback);
+    this.#onClick = callback;
+    if (this.dom) {
+      this.registerDomEvent(this.dom, "command", callback);
+    }
     return this;
   }
 
   onShowing(callback: (item: this) => any): this {
+    this.#onShowing.push(callback);
     callback(this);
-    this.registerDomEvent(this.menu.dom, "popupshowing", () => callback(this));
+    if (this.menu.mode === "dom") {
+      this.registerDomEvent(this.menu.dom, "popupshowing", () => callback(this));
+    }
     return this;
   }
 
@@ -83,6 +129,6 @@ export class MenuItem extends Component {
     return;
   }
   public onunload(): void {
-    this.dom.remove();
+    this.dom?.remove();
   }
 }

--- a/lib/zotero-helper/src/zotero/menu/menu.ts
+++ b/lib/zotero-helper/src/zotero/menu/menu.ts
@@ -22,22 +22,55 @@ interface PopupEl {
   /** whether remove given element when unload, default to true */
   removeSelf?: boolean;
 }
+interface VirtualPopup {
+  virtual: true;
+}
 const isSelector = (popup: PopupSelector | PopupEl): popup is PopupSelector =>
   typeof (popup as PopupSelector).selector === "string";
+const isVirtual = (
+  popup: PopupSelector | PopupEl | VirtualPopup,
+): popup is VirtualPopup => (popup as VirtualPopup).virtual === true;
+
+export interface VirtualMenuItemNode {
+  type: "item";
+  item: MenuItem;
+}
+
+export interface VirtualMenuSubmenuNode {
+  type: "submenu";
+  label: string;
+  menu: Menu;
+}
+
+export interface VirtualMenuSeparatorNode {
+  type: "separator";
+}
+
+export type VirtualMenuNode =
+  | VirtualMenuItemNode
+  | VirtualMenuSubmenuNode
+  | VirtualMenuSeparatorNode;
 
 /**
  * @public
  */
 export class Menu extends Component {
-  dom: XUL.MenuPopup;
+  dom!: XUL.MenuPopup;
   readonly removeSelf: boolean;
-  constructor(menuPopup: PopupSelector | PopupEl, parent?: Menu) {
+  readonly mode: "dom" | "virtual";
+  readonly nodes: VirtualMenuNode[] = [];
+  constructor(menuPopup: PopupSelector | PopupEl | VirtualPopup, parent?: Menu) {
     super();
     this.parentMenu = parent;
-    if (!isSelector(menuPopup)) {
+    if (isVirtual(menuPopup)) {
+      this.mode = "virtual";
+      this.removeSelf = false;
+    } else if (!isSelector(menuPopup)) {
+      this.mode = "dom";
       this.dom = menuPopup.element;
       this.removeSelf = menuPopup.removeSelf ?? true;
     } else {
+      this.mode = "dom";
       let selector: string | -1 | undefined =
         MenuSelector[menuPopup.selector as keyof typeof MenuSelector];
       if (selector === -1) {
@@ -51,9 +84,13 @@ export class Menu extends Component {
       this.removeSelf = false;
     }
 
-    if (!this.dom) {
+    if (this.mode === "dom" && !this.dom) {
       throw new Error(`Menu not found: ${menuPopup}`);
     }
+  }
+
+  static virtual(parent?: Menu) {
+    return new Menu({ virtual: true }, parent);
   }
 
   addItem(
@@ -64,7 +101,11 @@ export class Menu extends Component {
     const item = this.addChild(new MenuItem(this));
     cb(item);
 
-    this.insert(item.dom, insertBefore, anchor);
+    if (this.mode === "dom") {
+      this.insert(item.dom!, insertBefore, anchor);
+    } else {
+      this.nodes.push({ type: "item", item });
+    }
     return this;
   }
 
@@ -89,6 +130,12 @@ export class Menu extends Component {
     insertBefore = false,
     anchor?: XUL.Element,
   ): this {
+    if (this.mode === "virtual") {
+      const submenu = this.addChild(Menu.virtual(this));
+      cb(submenu);
+      this.nodes.push({ type: "submenu", label, menu: submenu });
+      return this;
+    }
     const submenuEl = createXULElement(
       this.dom.ownerDocument,
       "menu",
@@ -118,6 +165,10 @@ export class Menu extends Component {
    * @public
    */
   addSeparator(insertBefore = false, anchor?: XUL.Element): this {
+    if (this.mode === "virtual") {
+      this.nodes.push({ type: "separator" });
+      return this;
+    }
     const separatorEl = createXULElement(
       this.dom.ownerDocument,
       "menuseparator",
@@ -130,6 +181,6 @@ export class Menu extends Component {
     return;
   }
   public onunload(): void {
-    this.removeSelf && this.dom.remove();
+    this.removeSelf && this.dom?.remove();
   }
 }

--- a/lib/zotero-helper/src/zotero/menu/official.ts
+++ b/lib/zotero-helper/src/zotero/menu/official.ts
@@ -1,0 +1,114 @@
+import type { Menu, VirtualMenuNode } from "./menu.js";
+
+type MenuManagerContext = {
+  setVisible?: (visible: boolean) => void;
+  setEnabled?: (enabled: boolean) => void;
+  [key: string]: unknown;
+};
+
+type ReaderContextEvent = {
+  append: (entry: Record<string, unknown>) => void;
+};
+
+const menuTargets = {
+  menuFile: "main/menubar/file",
+  menuEdit: "main/menubar/edit",
+  menuView: "main/menubar/view",
+  menuGo: "main/menubar/go",
+  menuTools: "main/menubar/tools",
+  menuHelp: "main/menubar/help",
+  collection: "main/library/collection",
+  item: "main/library/item",
+} as const;
+
+export function resolveMenuTarget(selector: string) {
+  return menuTargets[selector as keyof typeof menuTargets] ?? null;
+}
+
+function applyItemState(node: VirtualMenuNode, context?: MenuManagerContext) {
+  if (node.type !== "item") return;
+  node.item.runShowingCallbacks();
+  context?.setVisible?.(!node.item.hidden);
+  context?.setEnabled?.(!node.item.disabled);
+}
+
+function toMenuManagerEntry(
+  node: VirtualMenuNode,
+): Record<string, unknown> | null {
+  if (node.type === "separator") {
+    return { menuType: "separator" };
+  }
+  if (node.type === "submenu") {
+    return {
+      menuType: "submenu",
+      label: node.label,
+      menus: node.menu.nodes
+        .map((child) => toMenuManagerEntry(child))
+        .filter(Boolean),
+    };
+  }
+  return {
+    menuType: "menuitem",
+    label: node.item.title,
+    icon: node.item.icon ?? undefined,
+    onShowing: (event: Event, context: MenuManagerContext) => {
+      void event;
+      applyItemState(node, context);
+    },
+    onCommand: (event: MouseEvent | KeyboardEvent, context: MenuManagerContext) => {
+      void context;
+      applyItemState(node);
+      if (node.item.hidden || node.item.disabled) return;
+      node.item.runCommand(event);
+    },
+  };
+}
+
+export function registerWithMenuManager(
+  app: typeof Zotero,
+  pluginID: string,
+  selector: string,
+  menu: Menu,
+) {
+  const target = resolveMenuTarget(selector);
+  if (!target || !("MenuManager" in app) || !app.MenuManager) {
+    return null;
+  }
+  const menuID = app.MenuManager.registerMenu({
+    menuID: `${pluginID}-${selector}-${app.Utilities.randomString()}`,
+    pluginID,
+    target,
+    menus: menu.nodes.map((node) => toMenuManagerEntry(node)).filter(Boolean),
+  });
+  return () => app.MenuManager.unregisterMenu(menuID);
+}
+
+function toReaderEntries(node: VirtualMenuNode): Record<string, unknown>[] {
+  if (node.type === "separator") {
+    return [{ type: "separator" }];
+  }
+  if (node.type === "submenu") {
+    return node.menu.nodes.flatMap((child) => toReaderEntries(child));
+  }
+  return [
+    {
+      label: node.item.title,
+      disabled: node.item.disabled,
+      onCommand: (event: MouseEvent | KeyboardEvent) => {
+        node.item.runShowingCallbacks();
+        if (node.item.hidden || node.item.disabled) return;
+        node.item.runCommand(event);
+      },
+    },
+  ];
+}
+
+export function appendReaderMenu(event: ReaderContextEvent, menu: Menu) {
+  for (const node of menu.nodes) {
+    node.type === "item" && node.item.runShowingCallbacks();
+    if (node.type === "item" && node.item.hidden) continue;
+    for (const entry of toReaderEntries(node)) {
+      event.append(entry);
+    }
+  }
+}

--- a/lib/zotero-helper/src/zotero/plugin.ts
+++ b/lib/zotero-helper/src/zotero/plugin.ts
@@ -13,6 +13,7 @@ import type {
 } from "./events.js";
 import type { MenuSelector } from "./menu/menu.js";
 import { Menu } from "./menu/menu.js";
+import { registerWithMenuManager, resolveMenuTarget } from "./menu/official.js";
 import { Component } from "./misc.js";
 import { polyfill } from "./polyfill/index.js";
 import type { Zotero7 } from "./polyfill/index.js";
@@ -240,11 +241,25 @@ abstract class Plugin_2<
   ): void {
     if (selector.startsWith(readerPrefix)) {
       if (!this.loaded) throw new Error("register reader Menu before loaded");
-      this.#readerMenu ??= this.addChild(new ReaderMenuHelper(this.app));
+      this.#readerMenu ??= this.addChild(
+        new ReaderMenuHelper(this.app, this.id.full),
+      );
       this.register(this.#readerMenu.event.on(toReaderEventName(selector), cb));
     } else {
-      const menu = this.addChild(new Menu({ selector }));
-      cb(menu);
+      if (resolveMenuTarget(selector) && this.app.MenuManager) {
+        const menu = Menu.virtual();
+        cb(menu);
+        const unregister = registerWithMenuManager(
+          this.app,
+          this.id.full,
+          selector,
+          menu,
+        );
+        unregister && this.register(unregister);
+      } else {
+        const menu = this.addChild(new Menu({ selector }));
+        cb(menu);
+      }
     }
   }
 

--- a/lib/zotero-helper/src/zotero/reader/event.ts
+++ b/lib/zotero-helper/src/zotero/reader/event.ts
@@ -1,7 +1,12 @@
 import { around } from "monkey-around";
 import { createNanoEvents } from "nanoevents";
 import { Component } from "../misc.js";
-import { onReaderOpen } from "./utils.js";
+import {
+  getReaderIframeWindow,
+  getReaderInstances,
+  getReaderPrototype,
+  onReaderOpen,
+} from "./utils.js";
 
 export interface ReaderEvent {
   "annot-select": (key: string, selected: boolean, itemId: number) => void;
@@ -19,16 +24,15 @@ export class ReaderEventHelper extends Component {
 
     self.app.log("hooking into _initIframeWindow");
     const reader = this.app.Reader;
+    const existingReaders = getReaderInstances(reader);
 
     // if reader is available, hook into existing iframe
-    if (this.#hookInitIframeWindow(reader._readers)) {
-      reader._readers.map((r) => this.#hookIframeWindow(r));
+    if (this.#hookInitIframeWindow()) {
+      existingReaders.map((r) => this.#hookIframeWindow(r));
       return;
     }
     this.register(
-      onReaderOpen(this.app.Reader, () =>
-        this.#hookInitIframeWindow(reader._readers),
-      ),
+      onReaderOpen(this.app.Reader, () => this.#hookInitIframeWindow()),
     );
   }
 
@@ -38,13 +42,20 @@ export class ReaderEventHelper extends Component {
   /**
    * @returns true if reader instance is available for hooking
    */
-  #hookInitIframeWindow(readers: _ZoteroTypes.ReaderInstance[]): boolean {
-    if (readers.length === 0) return false;
-    const instance = readers[0];
+  #hookInitIframeWindow(): boolean {
+    const prototype = getReaderPrototype(this.app.Reader);
+    if (!prototype) return false;
+    const methodName =
+      typeof (prototype as any)._initIframeWindow === "function"
+        ? "_initIframeWindow"
+        : typeof (prototype as any).initIframeWindow === "function"
+          ? "initIframeWindow"
+          : null;
+    if (!methodName) return false;
     const self = this;
     this.register(
-      around(instance.constructor.prototype as _ZoteroTypes.ReaderInstance, {
-        _initIframeWindow: (next) =>
+      around(prototype as _ZoteroTypes.ReaderInstance, {
+        [methodName]: (next: (...args: any[]) => any) =>
           function (this: _ZoteroTypes.ReaderInstance) {
             const result = next.call(this);
             self.#hookIframeWindow(this);
@@ -56,18 +67,19 @@ export class ReaderEventHelper extends Component {
   }
 
   public onunload(): void {
-    this.app.Reader._readers.forEach((r) => {
+    getReaderInstances(this.app.Reader).forEach((r) => {
       this.observers.get(r)?.disconnect();
       const onFocus = this.focusHandlers.get(r),
         onBlur = this.blurHandlers.get(r);
-      onFocus && r._iframeWindow?.removeEventListener("focus", onFocus);
-      onBlur && r._iframeWindow?.removeEventListener("blur", onBlur);
+      const iframeWindow = getReaderIframeWindow(r);
+      onFocus && iframeWindow?.removeEventListener("focus", onFocus);
+      onBlur && iframeWindow?.removeEventListener("blur", onBlur);
     });
   }
 
   async #hookIframeWindow(reader: _ZoteroTypes.ReaderInstance) {
     await reader._initPromise;
-    const window = reader._iframeWindow as unknown as typeof globalThis | null;
+    const window = getReaderIframeWindow(reader);
     if (!window) {
       this.app.logError(new Error("iframeWindow not found"));
       return;

--- a/lib/zotero-helper/src/zotero/reader/menu.ts
+++ b/lib/zotero-helper/src/zotero/reader/menu.ts
@@ -2,8 +2,13 @@
 import { around } from "monkey-around";
 import { createNanoEvents } from "nanoevents";
 import { Menu } from "../menu/menu.js";
+import { appendReaderMenu } from "../menu/official.js";
 import { Component } from "../misc.js";
-import { onReaderOpen } from "./utils.js";
+import {
+  getReaderPopupset,
+  getReaderPrototype,
+  onReaderOpen,
+} from "./utils.js";
 
 export interface AnnotPopupData {
   [key: string]: any;
@@ -67,12 +72,19 @@ export interface ReaderMenuEvent {
 export class ReaderMenuHelper extends Component {
   event = createNanoEvents<ReaderMenuEvent>();
 
-  constructor(public app: typeof Zotero) {
+  constructor(
+    public app: typeof Zotero,
+    private pluginID: string,
+  ) {
     super();
   }
 
   public onload(): void {
     const self = this;
+
+    if (this.#registerOfficialListeners()) {
+      return;
+    }
 
     self.app.log("hooking into _openAnnotationPopup");
     if (this.#hookOpenAnnotPopup()) return;
@@ -83,10 +95,90 @@ export class ReaderMenuHelper extends Component {
 
   patchedPopups = new WeakSet<Element>();
 
+  #registerOfficialListeners(): boolean {
+    const reader = this.app.Reader as _ZoteroTypes.Reader & {
+      registerEventListener?: (
+        type: string,
+        handler: (event: any) => void,
+        pluginID: string,
+      ) => void;
+      unregisterEventListener?: (type: string, handler: (event: any) => void) => void;
+    };
+    if (typeof reader.registerEventListener !== "function") {
+      return false;
+    }
+    const register = (
+      type: string,
+      emit: (event: any, menu: Menu) => void,
+    ) => {
+      const handler = (event: any) => {
+        try {
+          const menu = Menu.virtual();
+          emit(event, menu);
+          appendReaderMenu(event, menu);
+        } catch (error) {
+          this.app.logError(error as Error);
+        }
+      };
+      reader.registerEventListener!(type, handler, this.pluginID);
+      if (typeof reader.unregisterEventListener === "function") {
+        this.register(() => reader.unregisterEventListener!(type, handler));
+      }
+    };
+
+    register("createAnnotationContextMenu", (event, menu) => {
+      this.event.emit(
+        "annot",
+        menu,
+        event.params,
+        event.reader.itemID,
+        event.reader,
+      );
+    });
+    register("createViewContextMenu", (event, menu) => {
+      this.event.emit(
+        "page",
+        menu,
+        event.params,
+        event.reader.itemID,
+        undefined,
+        event.reader,
+      );
+    });
+    register("createColorContextMenu", (event, menu) => {
+      this.event.emit(
+        "color",
+        menu,
+        event.params,
+        event.reader.itemID,
+        event.reader,
+      );
+    });
+    register("createThumbnailContextMenu", (event, menu) => {
+      this.event.emit(
+        "thumbnail",
+        menu,
+        event.params,
+        event.reader.itemID,
+        event.reader,
+      );
+    });
+    register("createSelectorContextMenu", (event, menu) => {
+      this.event.emit(
+        "selector",
+        menu,
+        event.params,
+        event.reader.itemID,
+        event.reader,
+      );
+    });
+    return true;
+  }
+
   #hookOpenAnnotPopup(): boolean {
-    const readers = this.app.Reader._readers;
-    if (readers.length === 0) return false;
-    const reader = readers[0];
+    const prototype = getReaderPrototype(this.app.Reader);
+    if (!prototype) return false;
+    const proto = prototype as Record<string, unknown>;
     const self = this;
     function* menuFrom(popupset: Element) {
       for (const popup of popupset.children) {
@@ -113,107 +205,165 @@ export class ReaderMenuHelper extends Component {
       }
       return itemID;
     }
+    const resolveMethodName = (legacy: string, modern: string) =>
+      typeof proto[legacy] === "function"
+        ? legacy
+        : typeof proto[modern] === "function"
+          ? modern
+          : null;
+    const patches: Record<string, (next: (...args: any[]) => any) => any> = {};
+    const annotPopup = resolveMethodName(
+      "_openAnnotationPopup",
+      "openAnnotationPopup",
+    );
+    const pagePopup = resolveMethodName("_openPagePopup", "openPagePopup");
+    const tagsPopup = resolveMethodName("_openTagsPopup", "openTagsPopup");
+    const colorPopup = resolveMethodName("_openColorPopup", "openColorPopup");
+    const thumbnailPopup = resolveMethodName(
+      "_openThumbnailPopup",
+      "openThumbnailPopup",
+    );
+    const selectorPopup = resolveMethodName(
+      "_openSelectorPopup",
+      "openSelectorPopup",
+    );
+    if (annotPopup) {
+      patches[annotPopup] = (next) =>
+        function (
+          this: _ZoteroTypes.ReaderInstance,
+          data: AnnotPopupData,
+          ...args: unknown[]
+        ) {
+          const reader = this;
+          const result = next.call(this, data, ...args);
+          try {
+            const itemID = getItemID(this);
+            const popupset = getReaderPopupset(this);
+            if (!popupset) return result;
+            for (const menu of menuFrom(popupset)) {
+              self.event.emit("annot", menu, data, itemID, reader);
+            }
+          } catch (error) {
+            self.app.logError(error as Error);
+          }
+          return result;
+        };
+    }
+    if (pagePopup) {
+      patches[pagePopup] = (next) =>
+        function (
+          this: _ZoteroTypes.ReaderInstance,
+          data: unknown,
+          secondView: boolean,
+          ...args: unknown[]
+        ) {
+          const reader = this;
+          const result = next.call(this, data, secondView, ...args);
+          try {
+            const itemID = getItemID(this);
+            const popupset = getReaderPopupset(this);
+            if (!popupset) return result;
+            for (const menu of menuFrom(popupset)) {
+              self.event.emit("page", menu, data, itemID, secondView, reader);
+            }
+          } catch (error) {
+            self.app.logError(error as Error);
+          }
+          return result;
+        };
+    }
+    if (tagsPopup) {
+      patches[tagsPopup] = (next) =>
+        function (
+          this: _ZoteroTypes.ReaderInstance,
+          item: Zotero.Item,
+          selector: string,
+          ...args: unknown[]
+        ) {
+          const reader = this;
+          const result = next.call(this, item, selector, ...args);
+          try {
+            const itemID = getItemID(this);
+            const popupset = getReaderPopupset(this);
+            if (!popupset) return result;
+            for (const menu of menuFrom(popupset)) {
+              self.event.emit("tags", menu, item, itemID, selector, reader);
+            }
+          } catch (error) {
+            self.app.logError(error as Error);
+          }
+          return result;
+        };
+    }
+    if (colorPopup) {
+      patches[colorPopup] = (next) =>
+        function (
+          this: _ZoteroTypes.ReaderInstance,
+          data: AnnotPopupData,
+          ...args: unknown[]
+        ) {
+          const reader = this;
+          const result = next.call(this, data, ...args);
+          try {
+            const itemID = getItemID(this);
+            const popupset = getReaderPopupset(this);
+            if (!popupset) return result;
+            for (const menu of menuFrom(popupset)) {
+              self.event.emit("color", menu, data, itemID, reader);
+            }
+          } catch (error) {
+            self.app.logError(error as Error);
+          }
+          return result;
+        };
+    }
+    if (thumbnailPopup) {
+      patches[thumbnailPopup] = (next) =>
+        function (
+          this: _ZoteroTypes.ReaderInstance,
+          data: unknown,
+          ...args: unknown[]
+        ) {
+          const reader = this;
+          const result = next.call(this, data, ...args);
+          try {
+            const itemID = getItemID(this);
+            const popupset = getReaderPopupset(this);
+            if (!popupset) return result;
+            for (const menu of menuFrom(popupset)) {
+              self.event.emit("thumbnail", menu, data, itemID, reader);
+            }
+          } catch (error) {
+            self.app.logError(error as Error);
+          }
+          return result;
+        };
+    }
+    if (selectorPopup) {
+      patches[selectorPopup] = (next) =>
+        function (
+          this: _ZoteroTypes.ReaderInstance,
+          data: unknown,
+          ...args: unknown[]
+        ) {
+          const reader = this;
+          const result = next.call(this, data, ...args);
+          try {
+            const itemID = getItemID(this);
+            const popupset = getReaderPopupset(this);
+            if (!popupset) return result;
+            for (const menu of menuFrom(popupset)) {
+              self.event.emit("selector", menu, data, itemID, reader);
+            }
+          } catch (error) {
+            self.app.logError(error as Error);
+          }
+          return result;
+        };
+    }
+    if (Object.keys(patches).length === 0) return false;
     this.register(
-      around(reader.constructor.prototype as _ZoteroTypes.ReaderInstance, {
-        _openAnnotationPopup: (next) =>
-          function (
-            this: _ZoteroTypes.ReaderInstance,
-            data: AnnotPopupData,
-            ...args
-          ) {
-            const reader = this;
-            const result = next.call(this, data, ...args);
-            try {
-              const itemID = getItemID(this);
-              for (const menu of menuFrom(this._popupset)) {
-                self.event.emit("annot", menu, data, itemID, reader);
-              }
-            } catch (error) {
-              self.app.logError(error as Error);
-            }
-            return result;
-          },
-        _openPagePopup: (next) =>
-          function (
-            this: _ZoteroTypes.ReaderInstance,
-            data,
-            secondView,
-            ...args
-          ) {
-            const reader = this;
-            const result = next.call(this, data, secondView, ...args);
-            try {
-              const itemID = getItemID(this);
-              for (const menu of menuFrom(this._popupset as Element)) {
-                self.event.emit("page", menu, data, itemID, secondView, reader);
-              }
-            } catch (error) {
-              self.app.logError(error as Error);
-            }
-            return result;
-          },
-        _openTagsPopup: (next) =>
-          function (
-            this: _ZoteroTypes.ReaderInstance,
-            item: Zotero.Item,
-            selector: string,
-            ...args
-          ) {
-            const reader = this;
-            const result = next.call(this, item, selector, ...args);
-            try {
-              const itemID = getItemID(this);
-              for (const menu of menuFrom(this._popupset as Element)) {
-                self.event.emit("tags", menu, item, itemID, selector, reader);
-              }
-            } catch (error) {
-              self.app.logError(error as Error);
-            }
-            return result;
-          },
-        _openColorPopup: (next) =>
-          function (this: _ZoteroTypes.ReaderInstance, data, ...args) {
-            const reader = this;
-            const result = next.call(this, data, ...args);
-            try {
-              const itemID = getItemID(this);
-              for (const menu of menuFrom(this._popupset as Element)) {
-                self.event.emit("color", menu, data, itemID, reader);
-              }
-            } catch (error) {
-              self.app.logError(error as Error);
-            }
-            return result;
-          },
-        _openThumbnailPopup: (next) =>
-          function (this: _ZoteroTypes.ReaderInstance, data, ...args) {
-            const reader = this;
-            const result = next.call(this, data, ...args);
-            try {
-              const itemID = getItemID(this);
-              for (const menu of menuFrom(this._popupset as Element)) {
-                self.event.emit("thumbnail", menu, data, itemID, reader);
-              }
-            } catch (error) {
-              self.app.logError(error as Error);
-            }
-            return result;
-          },
-        _openSelectorPopup: (next) =>
-          function (this: _ZoteroTypes.ReaderInstance, data, ...args) {
-            const reader = this;
-            const result = next.call(this, data, ...args);
-            try {
-              const itemID = getItemID(this);
-              for (const menu of menuFrom(this._popupset as Element)) {
-                self.event.emit("selector", menu, data, itemID, reader);
-              }
-            } catch (error) {
-              self.app.logError(error as Error);
-            }
-            return result;
-          },
-      }),
+      around(prototype as _ZoteroTypes.ReaderInstance, patches),
     );
     return true;
   }

--- a/lib/zotero-helper/src/zotero/reader/utils.ts
+++ b/lib/zotero-helper/src/zotero/reader/utils.ts
@@ -1,5 +1,18 @@
 import { around } from "monkey-around";
 
+type ReaderWithInternals = _ZoteroTypes.ReaderInstance & {
+  _iframeWindow?: typeof globalThis | null;
+  _iframe?: { contentWindow?: typeof globalThis | null } | null;
+  _window?: typeof globalThis | null;
+  _popupset?: Element | null;
+  popupset?: Element | null;
+};
+
+type ReaderManager = _ZoteroTypes.Reader & {
+  _readers?: _ZoteroTypes.ReaderInstance[];
+  readers?: _ZoteroTypes.ReaderInstance[];
+};
+
 export const onReaderOpen = (
   reader: _ZoteroTypes.Reader,
   breakOn: (reader: _ZoteroTypes.Reader) => boolean,
@@ -13,4 +26,37 @@ export const onReaderOpen = (
       },
   });
   return unload;
+};
+
+export const getReaderInstances = (
+  reader: _ZoteroTypes.Reader,
+): _ZoteroTypes.ReaderInstance[] => {
+  const manager = reader as ReaderManager;
+  const instances = manager._readers ?? manager.readers;
+  return Array.isArray(instances) ? instances : [];
+};
+
+export const getReaderPrototype = (
+  reader: _ZoteroTypes.Reader,
+): _ZoteroTypes.ReaderInstance | undefined => {
+  return getReaderInstances(reader)[0]?.constructor?.prototype;
+};
+
+export const getReaderIframeWindow = (
+  reader: _ZoteroTypes.ReaderInstance,
+): typeof globalThis | null => {
+  const instance = reader as ReaderWithInternals;
+  return (
+    instance._iframeWindow ??
+    instance._iframe?.contentWindow ??
+    instance._window ??
+    null
+  );
+};
+
+export const getReaderPopupset = (
+  reader: _ZoteroTypes.ReaderInstance,
+): Element | null => {
+  const instance = reader as ReaderWithInternals;
+  return instance._popupset ?? instance.popupset ?? null;
 };

--- a/lib/zotero-helper/src/zotero/scaffold/bootstrap.js
+++ b/lib/zotero-helper/src/zotero/scaffold/bootstrap.js
@@ -88,9 +88,22 @@ export async function uninstall() {
 
 // 'Services' may not be available in Zotero 6
 function registerServices() {
-  Services ??= ChromeUtils.import(
-    "resource://gre/modules/Services.jsm",
-  ).Services;
+  if (Services) return;
+  if (typeof ChromeUtils.importESModule === "function") {
+    try {
+      Services = ChromeUtils.importESModule(
+        "resource://gre/modules/Services.sys.mjs",
+      ).Services;
+      return;
+    } catch (error) {
+      dump(`Failed to import Services.sys.mjs: ${error}\n`);
+    }
+  }
+  if (typeof ChromeUtils.import === "function") {
+    Services = ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
+    return;
+  }
+  throw new Error("Services is not available in bootstrap scope");
 }
 
 // In Zotero 6, bootstrap methods are called before Zotero is initialized, and using include.js


### PR DESCRIPTION


  This PR contains the Zotero-side split from #459.

  It updates the Zotero plugin for Zotero 8 compatibility, mainly around bootstrap, menus, and reader APIs.

  - add Zotero 8 bootstrap fallback via `Services.sys.mjs`
  - update item menu registration for Zotero 8
  - support newer reader menu/event APIs
  - harden annotation update logic for newer reader internals
  - set addon compatibility metadata to `strict_max_version: 8.*`

  This PR only contains the Zotero plugin side:

  - `app/zotero/**`
  - `lib/zotero-helper/**`

  The Obsidian-side changes remain in #459.