### PR TITLE
fix: handle missing annotationKey in newer Zotero annotation format

### DIFF
--- a/app/obsidian/src/services/note-parser/format.ts
+++ b/app/obsidian/src/services/note-parser/format.ts
@@ -20,7 +20,9 @@ export const { DataCitation, DataAnnotation } = scope({
   },
   DataAnnotation: {
     attachmentURI: itemURI,
-    annotationKey: "string",
+    "annotationKey?": "string",
     citationItem: "CitationItem",
+    "pageLabel?": "number|string",
+    "position?": "any",
   },
 }).compile();

--- a/app/obsidian/src/services/note-parser/service.ts
+++ b/app/obsidian/src/services/note-parser/service.ts
@@ -51,10 +51,12 @@ export class NoteParser extends Service {
     string,
     {
       commentHTML: string | null;
-      annotationKey: string;
+      annotationKey: string | null;
       citationKey: string;
       attachementKey: string;
       inline: boolean;
+      highlightText: string;
+      pageLabel: string | number | null;
     }
   >();
   tdService = new globalThis.TurndownService({ headingStyle: "atx" })
@@ -94,13 +96,15 @@ export class NoteParser extends Service {
         const commentNode = node as HTMLElement;
         const key = nanoid(10);
         this.annotations.set(key, {
-          annotationKey: annotation.annotationKey,
+          annotationKey: annotation.annotationKey ?? null,
           citationKey: keyFromItemURI(annotation.citationItem.uris[0])!,
           attachementKey: keyFromItemURI(annotation.attachmentURI)!,
           commentHTML: commentNode.textContent?.trim()
             ? commentNode.innerHTML
             : null,
           inline: false,
+          highlightText: (highlightEl as HTMLElement).textContent || "",
+          pageLabel: annotation.pageLabel ?? null,
         });
         return Placeholder.annot.create(key);
       },
@@ -137,11 +141,13 @@ export class NoteParser extends Service {
         const annotation = parseAnnotation(node.dataset.annotation!);
         const key = nanoid(10);
         this.annotations.set(key, {
-          annotationKey: annotation.annotationKey,
+          annotationKey: annotation.annotationKey ?? null,
           citationKey: keyFromItemURI(annotation.citationItem.uris[0])!,
           attachementKey: keyFromItemURI(annotation.attachmentURI)!,
           commentHTML: null,
           inline: true,
+          highlightText: content || "",
+          pageLabel: annotation.pageLabel ?? null,
         });
         return Placeholder.annot.create(key);
       },
@@ -264,7 +270,36 @@ export class NoteParser extends Service {
           log.error(`citation not found, key:`, key, annotData);
           throw new Error(`citation key not found: ${key}`);
         }
-        const annotation = docItem.annotations.get(annotData.annotationKey);
+        // When annotationKey is missing (newer Zotero format), try to
+        // find the annotation by falling back to all annotations of
+        // the attachment, or render a placeholder if not found.
+        let annotation = annotData.annotationKey
+          ? docItem.annotations.get(annotData.annotationKey)
+          : undefined;
+        if (!annotation && !annotData.annotationKey) {
+          // No annotationKey available (newer Zotero format uses
+          // pageLabel + position instead) — render the highlight text
+          // and comment with a page link as fallback.
+          log.warn(
+            `annotation missing annotationKey, using fallback`,
+            annotData,
+          );
+          let fallback = annotData.highlightText || "";
+          if (annotData.commentHTML) {
+            fallback +=
+              (fallback ? "\n" : "") + htmlToMarkdown(annotData.commentHTML);
+          }
+          if (fallback) {
+            const pageLink =
+              annotData.pageLabel && annotData.attachementKey
+                ? `  [p.${annotData.pageLabel}](zotero://open-pdf/library/items/${annotData.attachementKey}?page=${annotData.pageLabel})`
+                : "";
+            return annotData.inline
+              ? fallback + pageLink
+              : "\n" + fallback + pageLink + "\n";
+          }
+          return "";
+        }
         if (!annotation) {
           log.error(
             `annotation not found, key: `,


### PR DESCRIPTION
## Summary

- Newer Zotero (7+) embeds annotation references in notes without the `annotationKey` field, using `pageLabel` + `position` instead
- This caused the note parser to crash with: `Unexpected annotation data: annotationKey must be defined`
- Fix makes `annotationKey` optional, preserves highlight text content, and generates page-level PDF links as fallback

## Changes

### `format.ts`
- Made `annotationKey` optional in `DataAnnotation` schema
- Added `pageLabel` and `position` as optional fields to accept the newer format

### `service.ts`
- Added `highlightText` and `pageLabel` fields to the annotations map
- Store highlight text content and page label when processing annotations
- Graceful fallback when `annotationKey` is missing: renders the highlight text with a page-level PDF link instead of crashing
- No behavior change for older Zotero versions that still include `annotationKey`

## Test plan

- [x] Create literature note for item with newer-format annotation references (no `annotationKey`)
- [x] Verify no crash, highlight text preserved, page links generated
- [ ] Verify items with older format (with `annotationKey`) still work correctly