### PR TITLE
feat: auto-tag Zotero items when creating literature notes

### DIFF
--- a/app/zotero/prefs.json
+++ b/app/zotero/prefs.json
@@ -1,4 +1,6 @@
 {
   "notify": false,
-  "notify-url": "http://localhost:9091"
+  "notify-url": "http://localhost:9091",
+  "auto-tag": false,
+  "tag-name": "obsidian-note"
 }

--- a/app/zotero/public/prefs.xhtml
+++ b/app/zotero/public/prefs.xhtml
@@ -15,4 +15,20 @@
       >
     </hbox>
   </groupbox>
+  <groupbox>
+    <label><html:h2>Auto Tag</html:h2></label>
+    <checkbox
+      label="Auto-tag items when creating literature notes"
+      preference="extensions.zotero-obsidian-note.auto-tag"
+    />
+    <hbox>
+      <label>Tag Name</label>
+      <html:input
+        type="text"
+        preference="extensions.zotero-obsidian-note.tag-name"
+      >
+        > <html:label>Tag Name</html:label></html:input
+      >
+    </hbox>
+  </groupbox>
 </vbox>

--- a/app/zotero/src/main.ts
+++ b/app/zotero/src/main.ts
@@ -298,6 +298,18 @@ export default class ZoteroPlugin extends Plugin<typeof settings> {
       );
     if (items.length === 0) return;
     items = uniqBy(items, (i) => i.id);
+
+    // Auto-tag items when creating literature notes
+    if (action === "export" && this.settings["auto-tag"]) {
+      const tagName = this.settings["tag-name"] || "obsidian-note";
+      for (const item of items) {
+        if (!item.hasTag(tagName)) {
+          item.addTag(tagName);
+          item.saveTx();
+        }
+      }
+    }
+
     this.sendToObsidian("item", action, items);
   }
 


### PR DESCRIPTION
## Summary

- Adds an opt-in feature that automatically tags Zotero items when "Create Literature Note(s)" is triggered
- Helps users identify in Zotero which items already have corresponding notes in Obsidian
- Tag name is configurable (default: `obsidian-note`), disabled by default

## Changes

- **`prefs.json`**: Added `auto-tag` (boolean) and `tag-name` (string) settings
- **`prefs.xhtml`**: Added preferences UI with checkbox and text input
- **`main.ts`**: Added tagging logic in `handleSelectedItems` — only on `export` action, skips items that already have the tag

## Test plan

- [ ] Enable auto-tag in Zotero plugin preferences
- [ ] Right-click item → Create Literature Note → verify tag appears in Zotero
- [ ] Repeat for same item → verify no duplicate tag
- [ ] Disable auto-tag → verify no tag is added
- [ ] Customize tag name → verify custom name is used