### PR TITLE
feat: add custom column showing Obsidian note status in Zotero

### DIFF
--- a/app/obsidian/src/services/server/service.ts
+++ b/app/obsidian/src/services/server/service.ts
@@ -127,6 +127,27 @@ export class Server extends Service implements Events {
     const action = pathname.substring(1),
       // use bg: prefix to avoid conflict with obsidian protocol actions
       event = `bg:${pathname.substring(1)}`;
+
+    // Return all items that have literature notes in the vault
+    if (action === "note-status-all") {
+      const vault = this.plugin.app.vault;
+      const mc = this.plugin.app.metadataCache;
+      const results: Record<string, { exists: boolean; mtime: number }> = {};
+      for (const file of vault.getMarkdownFiles()) {
+        const cache = mc.getFileCache(file);
+        const key = cache?.frontmatter?.["zotero-key"];
+        if (typeof key === "string" && key.length > 0) {
+          results[key] = { exists: true, mtime: file.stat?.mtime ?? 0 };
+        }
+      }
+      response.writeHead(200, {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      });
+      response.end(JSON.stringify(results));
+      return;
+    }
+
     if (bgActions.has(action)) {
       const params = Object.fromEntries(searchParams.entries());
       if (request.headers["content-type"] === "application/json") {

--- a/app/zotero/src/main.ts
+++ b/app/zotero/src/main.ts
@@ -33,8 +33,76 @@ export default class ZoteroPlugin extends Plugin<typeof settings> {
    */
   readerFocus = new Map<string, number>();
   lastActiveReader: number | null = null;
+
+  /** Cache of note status per item key: "synced" | "none" */
+  private _noteStatusCache: Record<string, string> = {};
+
+  /** Fetch note status from Obsidian and refresh the column */
+  async refreshNoteStatus(): Promise<void> {
+    const url = this.settings["notify-url"];
+    if (!url) return;
+    try {
+      const resp = await fetch(new URL("/note-status-all", url));
+      const data = await resp.json();
+      this._noteStatusCache = {};
+      for (const key of Object.keys(data)) {
+        this._noteStatusCache[key] = "synced";
+      }
+      // @ts-expect-error Zotero 7 API
+      Zotero.ItemTreeManager.refreshColumns();
+    } catch (e) {
+      this.app.log("refreshNoteStatus error: " + e);
+    }
+  }
+
   onload(): void {
     this.app.log("zotero-obsidian-note Loaded");
+
+    // Register custom column showing Obsidian note status
+    setTimeout(() => {
+      try {
+        // @ts-expect-error Zotero 7 API
+        Zotero.ItemTreeManager.registerColumn({
+          dataKey: "obsidian-note-status",
+          label: "Obsidian",
+          pluginID: "zotero-obsidian-note@aidenlx.top",
+          dataProvider: (item: Zotero.Item) => {
+            return this._noteStatusCache[item.key] || "none";
+          },
+          renderCell: (
+            index: number,
+            data: string,
+            column: { className?: string },
+          ) => {
+            const doc = (globalThis as any).mainWindow?.document ?? document;
+            const cell = doc.createElementNS(
+              "http://www.w3.org/1999/xhtml",
+              "span",
+            );
+            cell.className = `cell ${column.className || ""}`;
+            cell.style.display = "flex";
+            cell.style.alignItems = "center";
+            cell.style.justifyContent = "center";
+            const dot = doc.createElementNS(
+              "http://www.w3.org/1999/xhtml",
+              "span",
+            );
+            const color =
+              data === "synced"
+                ? "#4caf50"
+                : data === "outdated"
+                  ? "#ff9800"
+                  : "#f44336";
+            dot.style.cssText = `display:inline-block;width:8px;height:8px;border-radius:50%;background:${color}`;
+            cell.appendChild(dot);
+            return cell;
+          },
+        });
+      } catch (e) {
+        this.app.log("registerColumn error: " + e);
+      }
+      this.refreshNoteStatus();
+    }, 5000);
 
     this.registerReaderEvent("focus", (itemId, instanceId) => {
       this.app.log(`reader focus: ${itemId}, ${instanceId}`);


### PR DESCRIPTION
## Summary

Adds a custom "Obsidian" column to Zotero's item list that displays colored dots indicating whether each item has a corresponding literature note in Obsidian:

- 🟢 Green: note exists in Obsidian vault
- 🔴 Red: no note found

This helps users quickly identify which items have been processed without leaving Zotero.

## Changes

### Obsidian plugin (`server/service.ts`)
- Added `/note-status-all` GET endpoint to the HTTP server
- Scans all vault markdown files for `zotero-key` frontmatter
- Returns JSON map of `{ itemKey: { exists, mtime } }`

### Zotero plugin (`main.ts`)
- Registers custom column via `Zotero.ItemTreeManager.registerColumn()`
- Fetches note status from Obsidian's HTTP server on plugin load
- Caches results and renders colored dots in the column
- Column registration is wrapped in setTimeout + try-catch to avoid blocking plugin initialization

## Test plan

- [x] Enable "Obsidian" column via right-click on Zotero column header
- [x] Items without notes show red dot
- [x] Items with literature notes show green dot
- [x] Status refreshes on plugin load
- [ ] Verify no impact on existing Zotero/Obsidian functionality