### PR TITLE
docs(github): require Obsidian debug info in bug reports

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/bug-reports.yml
+++ b/.github/DISCUSSION_TEMPLATE/bug-reports.yml
@@ -17,6 +17,12 @@ body:
         duplicate. General usage questions belong in
         [Help](https://github.com/aidenlx/zotlit/discussions/categories/help)
         instead.
+
+
+        Follow
+        [Collect debug logs](https://zotlit.aidenlx.site/docs/how-to/collect-debug-logs)
+        to gather the Obsidian debug info, the ZotLit log archive, and the
+        Zotero debug output that this report asks for.
   - type: input
     id: zotlit-version
     attributes:
@@ -31,6 +37,17 @@ body:
       label: Host application versions
       description: Obsidian, Zotero, and OS versions.
       placeholder: e.g. Obsidian 1.7.2, Zotero 7.0.9, macOS 15.1
+    validations:
+      required: true
+  - type: textarea
+    id: obsidian-debug-info
+    attributes:
+      label: Obsidian debug info
+      description: >-
+        In Obsidian, open the command palette and run "Show debug info", then
+        paste the copied output here. See
+        [Collect debug logs](https://zotlit.aidenlx.site/docs/how-to/collect-debug-logs#obsidian-debug-info).
+      render: text
     validations:
       required: true
   - type: dropdown

--- a/apps/docs/content/docs/how-to/collect-debug-logs.mdx
+++ b/apps/docs/content/docs/how-to/collect-debug-logs.mdx
@@ -20,7 +20,7 @@ Once you have the logs, file the report in the [Bug reports discussion](https://
   once, then save logs from both sides.
 </Callout>
 
-## Obsidian debug info
+## Obsidian debug info [#obsidian-debug-info]
 
 <Steps>
   <Step>

--- a/packages/scripts/scripts/release.ts
+++ b/packages/scripts/scripts/release.ts
@@ -72,10 +72,9 @@ if (currentBranch !== "main" && currentBranch !== "next") {
 // Sync the current branch with origin before bumping. For pre-releases and
 // hotfixes, basing the release branch on `origin/${currentBranch}` keeps only the
 // version-bump commit in the PR. For stable graduations from next, the PR carries
-// all of next's changes to main (the promotion). Pushing first avoids dragging
-// unpushed commits into the release branch. `HEAD` for a local-only branch.
-const remoteExists = await assertBranchSynced(currentBranch);
-const baseRef = remoteExists ? `origin/${currentBranch}` : "HEAD";
+// all of next's changes to main (the promotion). `resolveBaseRef` picks that base
+// and reconciles a branch that runs ahead of origin.
+const baseRef = await resolveBaseRef(currentBranch);
 
 const selection = await p.select({
   message: "Which app(s) to release?",
@@ -464,22 +463,27 @@ async function assertCleanWorkingTree(): Promise<void> {
 }
 
 /**
- * Fetches `origin/${branch}` and requires local to match it before releasing, so
- * the release branch (cut from the remote tip) carries only the version bump.
- * Offers to push when the branch is merely ahead; aborts on behind/diverged since
- * the base would be stale.
+ * Fetches `origin/${branch}` and resolves the ref the release branch is cut from,
+ * so that branch (cut from the remote tip) carries only the version bump. Aborts
+ * on behind/diverged since the base would be stale.
  *
- * @returns whether an origin counterpart exists — `false` for a local-only
- *   branch, whose release branch falls back to `HEAD`.
+ * A branch that is merely ahead is reconciled per branch. `main` accepts commits
+ * through pull requests only — a repository ruleset restricts it to merge commits
+ * and rejects direct pushes — so its unpushed commits ride along in the release PR
+ * from a `HEAD` base. Other branches offer a push, which keeps the PR down to the
+ * version-bump commit.
+ *
+ * @returns the git ref to cut the release branch from — `HEAD` for a local-only
+ *   branch, or for `main` carrying unpushed commits.
  */
-async function assertBranchSynced(branch: string): Promise<boolean> {
+async function resolveBaseRef(branch: string): Promise<string> {
   const fetched = await $({
     cwd: workspaceRoot,
     nothrow: true,
   })`git fetch origin ${branch}`;
   if (fetched.exitCode !== 0) {
     p.log.warn(`No origin/${branch}: basing the release branch on local HEAD.`);
-    return false;
+    return "HEAD";
   }
 
   const counts = (
@@ -501,18 +505,25 @@ async function assertBranchSynced(branch: string): Promise<boolean> {
     );
     process.exit(1);
   }
-  if (ahead > 0) {
-    const push = await p.confirm({
-      message: `"${branch}" has ${ahead} commit(s) not on origin/${branch}. Push them before bumping the version?`,
-    });
-    if (p.isCancel(push) || !push) cancel();
-    const s = p.spinner();
-    s.start(`Pushing ${branch} to origin`);
-    await $({ cwd: workspaceRoot })`git push origin ${branch}`;
-    s.stop(`Pushed ${branch}`);
+  if (ahead === 0) return `origin/${branch}`;
+
+  if (branch === "main") {
+    p.log.info(
+      `"${branch}" has ${ahead} commit(s) not on origin/${branch}: they ride along in the release PR.`,
+    );
+    return "HEAD";
   }
 
-  return true;
+  const push = await p.confirm({
+    message: `"${branch}" has ${ahead} commit(s) not on origin/${branch}. Push them before bumping the version?`,
+  });
+  if (p.isCancel(push) || !push) cancel();
+  const s = p.spinner();
+  s.start(`Pushing ${branch} to origin`);
+  await $({ cwd: workspaceRoot })`git push origin ${branch}`;
+  s.stop(`Pushed ${branch}`);
+
+  return `origin/${branch}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Bug-report discussion template links the [Collect debug logs](https://zotlit.aidenlx.site/docs/how-to/collect-debug-logs) how-to and adds a **required** `Obsidian debug info` textarea for the output of the Obsidian `Show debug info` command (`render: text`).
- The how-to's "Obsidian debug info" heading gets a stable `[#obsidian-debug-info]` anchor, since the template deep-links to it.
- Separate commit: `release.ts` resolves the release base ref per branch. A repository ruleset restricts `main` to merge commits, so the old "push before bumping" prompt could never succeed there; `main` now bases the release branch on `HEAD` and carries its unpushed commits in the release PR.

## Test plan

- `yaml.safe_load` parses the template; field order is version → host versions → debug info → sandbox → repro → expected → actual → logs.
- Pre-commit `oxlint` + `oxfmt` clean on `release.ts`.