### PR TITLE
docs: warn about the Obsidian installer requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@
 
 </div>
 
+> [!WARNING]
+> **Update the Obsidian installer first.** ZotLit needs Obsidian 1.13.4 or newer, and the **installer version** must also be 1.13.4 or newer. Obsidian's in-app update does not replace the installer. Check yours in **Settings → About**.
+>
+> If the installer is older, ZotLit does not load. Obsidian shows _Failed to load plugin "zotlit"_, and the developer console shows a `SyntaxError`.
+>
+> **Fix:** download Obsidian from [obsidian.md/download](https://obsidian.md/download) and run it over your current installation. Nothing is deleted, and no notes are lost. [Full steps →](https://zotlit.aidenlx.site/docs/how-to/update-obsidian-installer)
+
 > [!NOTE]
 > **Coming from v1?** v2 is a major upgrade with breaking changes. Your existing literature notes and custom templates do not carry over unchanged. Read the [migration guide](https://zotlit.aidenlx.site/docs/how-to/migrate-from-v1) before upgrading.
 

--- a/apps/docs/content/changelog/2.0.0.mdx
+++ b/apps/docs/content/changelog/2.0.0.mdx
@@ -9,6 +9,12 @@ This is the first public stable release of ZotLit v2. If you participated in the
 
 The changes below cover what landed since beta.4; for the full v2 feature set, see the [release announcement](/blog/v2-release).
 
+## Before you update
+
+ZotLit needs Obsidian 1.13.4 or newer, and your **installer version** must also be 1.13.4 or newer. Obsidian's in-app update does not replace the installer. Check yours in **Settings > About**. If the installer is older, ZotLit does not load: Obsidian shows _Failed to load plugin "zotlit"_, and the developer console shows a `SyntaxError`.
+
+To fix this, download Obsidian from the [download page](https://obsidian.md/download) and run the installer over your current installation. Nothing is deleted, and no notes are lost. See [how to update the Obsidian installer](/docs/how-to/update-obsidian-installer) and the [beta.4 requirement note](/changelog/2.0.0-beta.4#obsidian-version-requirement).
+
 ## License
 
 ZotLit is now licensed under AGPL-3.0-or-later (previously MIT). The change covers code ported from Zotero, which is itself AGPL-licensed. This does not affect how you use the plugin.

--- a/apps/docs/content/docs/(intro)/install-zotlit.mdx
+++ b/apps/docs/content/docs/(intro)/install-zotlit.mdx
@@ -7,8 +7,13 @@ import { Tabs, Tab } from "@/components/tabs";
 import { VersionLedger } from "@/components/version-ledger";
 import { ActionLink } from "@/components/action-link";
 import { Steps, Step } from "fumadocs-ui/components/steps";
+import { Callout } from "fumadocs-ui/components/callout";
 
 ZotLit is a desktop-only Obsidian plugin. It runs on Windows, macOS, and Linux; mobile is not supported.
+
+<Callout type="warn" title="Update the Obsidian installer first">
+  ZotLit needs Obsidian 1.13.4 or newer, and your **installer version** must also be 1.13.4 or newer. Obsidian's in-app update does not replace the installer. Check yours in **Settings > About**, then read [how to update the Obsidian installer](/docs/how-to/update-obsidian-installer). If the installer is older, ZotLit does not load.
+</Callout>
 
 ## Install the plugin
 

--- a/apps/docs/content/docs/how-to/update-obsidian-installer.mdx
+++ b/apps/docs/content/docs/how-to/update-obsidian-installer.mdx
@@ -1,12 +1,12 @@
 ---
 title: "How to update the Obsidian installer"
-description: "Update Obsidian's bundled Electron version when ZotLit asks you to run the latest installer."
+description: "Update Obsidian's bundled Electron version when ZotLit asks you to run the latest installer, or when ZotLit does not load with a SyntaxError."
 ---
 
 import { Steps, Step } from "fumadocs-ui/components/steps";
 import { Callout } from "fumadocs-ui/components/callout";
 
-Use this guide when ZotLit shows the persistent **Update Obsidian to use ZotLit** notice.
+Use this guide when ZotLit shows the persistent **Update Obsidian to use ZotLit** notice, or when ZotLit does not load at all: Obsidian shows _Failed to load plugin "zotlit"_, and the developer console shows a `SyntaxError`.
 
 Obsidian's automatic updates can update the app version, but they cannot replace the Electron component bundled with the desktop app. ZotLit needs a newer Electron version. An installer update means downloading and running the current Obsidian installer over your existing installation.
 


### PR DESCRIPTION
## Why

Reported in #635. On an Obsidian installer older than 1.13.4, ZotLit does not load at all.

The bundle is built with `target: "es2025"`, so `using` declarations reach the output. Obsidian loads a plugin through a single whole-file `window.eval` (`app.js:150969-150975`), so an unsupported *syntax* feature is a parse error: `main.js` never begins executing, and the in-plugin `assertElectronVersion()` guard cannot run.

The only thing the user sees is Obsidian's own notice, `Failed to load plugin “zotlit”`, which carries no reason. The cause appears solely in the developer console as `Plugin failure: zotlit SyntaxError: Unexpected identifier 's'`.

No manifest field can gate on this: `minAppVersion` is not read at load time, and it compares the **app** version, never the installer version.

Affected: installer 1.8.10 and older (Electron ≤ 34 / Chromium ≤ 132). `using` needs Chromium 134 = Electron 35. The Obsidian 1.13.4 installer ships Electron 43.1.1.

## What changed

- **README** — a `[!WARNING]` callout above the v1 note: the requirement, the symptom (including `SyntaxError` as a search hook), and the fix with a reassurance that no notes are lost.
- **Install page** — a `warn` callout before the install steps, which previously said nothing about the installer.
- **Installer how-to** — the opener assumed the user had seen ZotLit's notice. Affected users never see it, so it now covers both doors; `description` names `SyntaxError`.
- **2.0.0 changelog** — a "Before you update" section. The requirement was announced in beta.4, which stable-channel readers skip.

## Not in scope

Lowering the build target to `es2023` (the floor at which Rolldown/oxc lowers explicit resource management) would let the bundle parse everywhere, so the existing guard could show ZotLit's own notice instead. Deliberately left out of this docs change.