### PR TITLE
docs: update license footer text and link backstory blog post

### DIFF
--- a/apps/docs/DESIGN.md
+++ b/apps/docs/DESIGN.md
@@ -114,7 +114,7 @@ body):
   leader, mono-uppercase orange link into the docs — with a one-line
   description under each.
 - **Shared copyright footer** (`components/site-footer.tsx`): hairline-topped
-  "© year AidenLx · MIT Licensed" line, shared across all `(home)` index
+  "© year AidenLx · AGPL-3.0 Licensed" line, shared across all `(home)` index
   surfaces (landing, blog index, changelog index).
 
 ### Changelog (`/changelog`)

--- a/apps/docs/components/site-footer.tsx
+++ b/apps/docs/components/site-footer.tsx
@@ -13,7 +13,7 @@ export function SiteFooter() {
           rel="noreferrer noopener"
           className="underline decoration-fd-border underline-offset-4 transition-colors hover:text-fd-primary hover:decoration-fd-primary"
         >
-          MIT Licensed
+          AGPL-3.0 Licensed
         </a>
       </span>
     </footer>

--- a/apps/docs/content/blog/v2-release.mdx
+++ b/apps/docs/content/blog/v2-release.mdx
@@ -26,7 +26,7 @@ Requires Obsidian 1.13.4+ desktop. Upgrading from v1? [Jump to migration](#upgra
 
 v1 relied on a native SQLite binding that broke every time Obsidian updated its Electron runtime. Users hit error dialogs and black screens. Replacing that dependency meant rebuilding most of the plugin, so v2 also simplifies the internals.
 
-_For the full backstory, see [Rebuilding ZotLit: the v2 public beta](/blog/rebuilding-zotlit-v2-public-beta)._
+_For the full backstory, see [Rebuilding ZotLit: the v2 public beta](/blog/rebuilding-zotlit-v2-public-beta), and for the longer personal story behind the decision to rebuild, see [Reconnecting the Dots](https://aidenlx.site/blog/reconnecting-dots)._
 
 ## Annotation workspace
 


### PR DESCRIPTION
## Summary
- Update the docs-site footer to say "AGPL-3.0 Licensed" instead of "MIT Licensed", matching the repo's actual license.
- Link the v2 release blog post's rewrite backstory to the personal blog post "Reconnecting the Dots", matching the reference already present in the public-beta blog post.