### PR TITLE
docs: license label and tutorial credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,6 @@ Questions, help, and bug reports: [Community](https://zotlit.aidenlx.site/commun
 
 <div align="center">
 
-[MIT License](LICENSE) · [Credits](https://zotlit.aidenlx.site/docs/credits) · Not affiliated with Obsidian or Zotero
+[AGPL-3.0-or-later](LICENSE) · [Credits](https://zotlit.aidenlx.site/docs/credits) · Not affiliated with Obsidian or Zotero
 
 </div>

--- a/apps/docs/content/docs/(intro)/credits.mdx
+++ b/apps/docs/content/docs/(intro)/credits.mdx
@@ -18,8 +18,8 @@ Projects that inspired ZotLit.
 
 Community members who wrote tutorials for ZotLit v1 before the documentation existed.
 
-- [@FeralFlora](https://github.com/FeralFlora)
-- [@MichaTarlton](https://github.com/MichaTarlton)
+- [@FeralFlora](https://github.com/FeralFlora): [ZotLit template walkthrough](https://forum.obsidian.md/t/zotlit-previously-obsidian-zotero-import-templates/56901) (Obsidian Forum)
+- [@MichaTarlton](https://github.com/MichaTarlton): [Beginner's set up for AidenLX's Zotero Integration Plugin](https://gist.github.com/MichaTarlton/67c24bfe65bb4cc2c6158e67363a4b45) (Gist)
 
 ## Contributors
 


### PR DESCRIPTION
Two doc commits:

1. **README footer** — state AGPL-3.0-or-later instead of MIT, matching the LICENSE file and package.json SPDX identifier.
2. **Credits page** — add links and descriptions to the two tutorial-author entries.

No behavior changes.