### PR TITLE
docs: redirect unpublished changelog versions to the beta site

### DIFF
--- a/apps/docs/app/(home)/changelog/[version]/page.tsx
+++ b/apps/docs/app/(home)/changelog/[version]/page.tsx
@@ -1,5 +1,5 @@
 import { type Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 
 import { BackCrumb } from "@/components/back-crumb";
 import { JsonLd } from "@/components/json-ld";
@@ -12,6 +12,8 @@ import {
   changelogRoute,
   formatReleaseDate,
   gitConfig,
+  isProductionDeployment,
+  zotlitBetaUrl,
 } from "@/lib/shared";
 import { changelog, getChangelogPages } from "@/lib/source";
 import {
@@ -19,7 +21,18 @@ import {
   changelogArticleSchema,
 } from "@/lib/structured-data";
 
-export const dynamicParams = false;
+// Versions this site never published (pre-release/beta builds) still live on
+// the beta site; render them on demand so the lookup below can redirect
+// there on the production deployment instead of 404ing.
+export const dynamicParams = true;
+
+/** 307s to the beta site's copy of `version` on the production deployment; 404s elsewhere. */
+function notFoundOrBetaRedirect(version: string): never {
+  if (isProductionDeployment) {
+    redirect(`${zotlitBetaUrl}${changelogRoute}/${version}`);
+  }
+  notFound();
+}
 
 function isLatest(version: string): boolean {
   const [latest] = getChangelogPages();
@@ -31,7 +44,7 @@ export default async function ChangelogVersionPage(
 ) {
   const params = await props.params;
   const page = changelog.getPage([params.version]);
-  if (!page) notFound();
+  if (!page) notFoundOrBetaRedirect(params.version);
 
   const { version, date, description, companion, body: MDX } = page.data;
 
@@ -109,7 +122,7 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   const params = await props.params;
   const page = changelog.getPage([params.version]);
-  if (!page) notFound();
+  if (!page) notFoundOrBetaRedirect(params.version);
 
   const { version, description, date } = page.data;
 

--- a/apps/docs/lib/shared.ts
+++ b/apps/docs/lib/shared.ts
@@ -17,6 +17,12 @@ export const gitConfig = {
 };
 
 export const zotlitLegacyUrl = "https://zotlit-v1.aidenlx.site";
+export const zotlitBetaUrl = "https://zotlit-beta.aidenlx.site";
+
+// Vercel sets `VERCEL_ENV` to "production" only for the deployment bound to
+// the production domain (zotlit.aidenlx.site) — preview deployments and
+// local dev do not get it.
+export const isProductionDeployment = process.env.VERCEL_ENV === "production";
 
 // The OG card each `[type, …]` slug selects; kept here so both the `/og`
 // route and page-level metadata (`ogImageUrl`/`pageMetadata`) share one


### PR DESCRIPTION
## Summary
- `/changelog/<version>` for a version this site never published (a pre-release/beta build) now 307s to its copy on `zotlit-beta.aidenlx.site` instead of returning a 404.
- Gated to the production Vercel deployment (`VERCEL_ENV === "production"`); preview deployments and local dev keep the plain 404.

## Verification
- `pnpm lint --filter=@zotlit/docs`: 0 warnings, 0 errors.
- `next build` + `next start` (no `VERCEL_ENV`): unpublished version → 404.
- `next build` + `next start` (`VERCEL_ENV=production`): unpublished version → 307 to `https://zotlit-beta.aidenlx.site/changelog/<version>`; published version still 200.