### PR TITLE
fix(docs): redirect og and llms.mdx changelog routes to beta site

### DIFF
--- a/apps/docs/app/(home)/changelog/[version]/page.tsx
+++ b/apps/docs/app/(home)/changelog/[version]/page.tsx
@@ -1,9 +1,9 @@
 import { type Metadata } from "next";
-import { notFound, redirect } from "next/navigation";
 
 import { BackCrumb } from "@/components/back-crumb";
 import { JsonLd } from "@/components/json-ld";
 import { getMDXComponents } from "@/components/mdx";
+import { notFoundOrBetaRedirect } from "@/lib/beta-redirect";
 import { cn } from "@/lib/cn";
 import { changelogProseRoles } from "@/lib/prose";
 import { pageMetadata } from "@/lib/seo";
@@ -12,8 +12,6 @@ import {
   changelogRoute,
   formatReleaseDate,
   gitConfig,
-  isProductionDeployment,
-  zotlitBetaUrl,
 } from "@/lib/shared";
 import { changelog, getChangelogPages } from "@/lib/source";
 import {
@@ -26,14 +24,6 @@ import {
 // there on the production deployment instead of 404ing.
 export const dynamicParams = true;
 
-/** 307s to the beta site's copy of `version` on the production deployment; 404s elsewhere. */
-function notFoundOrBetaRedirect(version: string): never {
-  if (isProductionDeployment) {
-    redirect(`${zotlitBetaUrl}${changelogRoute}/${version}`);
-  }
-  notFound();
-}
-
 function isLatest(version: string): boolean {
   const [latest] = getChangelogPages();
   return latest?.data.version === version;
@@ -44,7 +34,7 @@ export default async function ChangelogVersionPage(
 ) {
   const params = await props.params;
   const page = changelog.getPage([params.version]);
-  if (!page) notFoundOrBetaRedirect(params.version);
+  if (!page) notFoundOrBetaRedirect(`${changelogRoute}/${params.version}`);
 
   const { version, date, description, companion, body: MDX } = page.data;
 
@@ -122,7 +112,7 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   const params = await props.params;
   const page = changelog.getPage([params.version]);
-  if (!page) notFoundOrBetaRedirect(params.version);
+  if (!page) notFoundOrBetaRedirect(`${changelogRoute}/${params.version}`);
 
   const { version, description, date } = page.data;
 

--- a/apps/docs/app/llms.mdx/changelog/[[...slug]]/route.ts
+++ b/apps/docs/app/llms.mdx/changelog/[[...slug]]/route.ts
@@ -1,5 +1,4 @@
-import { notFound } from "next/navigation";
-
+import { notFoundOrBetaRedirect } from "@/lib/beta-redirect";
 import {
   changelog,
   getChangelogIndexLLMText,
@@ -23,7 +22,8 @@ export async function GET(
   }
 
   const page = changelog.getPage(path);
-  if (!page) notFound();
+  if (!page)
+    notFoundOrBetaRedirect(`/llms.mdx/changelog/${path.join("/")}/content.md`);
 
   return new Response(await getChangelogLLMText(page), { headers });
 }

--- a/apps/docs/app/og/[...slug]/route.tsx
+++ b/apps/docs/app/og/[...slug]/route.tsx
@@ -5,6 +5,7 @@ import { assertNever } from "@std/assert/unstable-never";
 import { notFound } from "next/navigation";
 
 import { ogImage } from "@/app/og/_render";
+import { notFoundOrBetaRedirect } from "@/lib/beta-redirect";
 import { baseURL, formatReleaseDate, type OgType, ogTypes } from "@/lib/shared";
 import { blog, changelog, source } from "@/lib/source";
 
@@ -80,7 +81,8 @@ export async function GET(
           meta: `${baseURL}/changelog`,
         });
       const page = changelog.getPage(ids);
-      if (!page) notFound();
+      if (!page)
+        notFoundOrBetaRedirect(`/og/changelog/${ids.join("/")}/image.webp`);
       return ogImage({
         kind: "Changelog",
         title: page.data.title ?? `v${page.data.version}`,

--- a/apps/docs/lib/beta-redirect.ts
+++ b/apps/docs/lib/beta-redirect.ts
@@ -1,0 +1,18 @@
+import { notFound, redirect } from "next/navigation";
+
+import { isProductionDeployment, zotlitBetaUrl } from "@/lib/shared";
+
+/**
+ * 307s to the beta site's copy of `path` on the production deployment;
+ * 404s elsewhere. `path` is the current site's local path (e.g.
+ * `/changelog/1.0.0` or `/og/changelog/1.0.0/image.webp`) — versions this
+ * site never published (pre-release/beta builds) still live on the beta
+ * site, so unresolved changelog lookups fall through here instead of 404ing
+ * on production.
+ */
+export function notFoundOrBetaRedirect(path: string): never {
+  if (isProductionDeployment) {
+    redirect(`${zotlitBetaUrl}${path}`);
+  }
+  notFound();
+}


### PR DESCRIPTION
## Summary

The previous commit (dc98c6f5 → 3f3cc02d) redirected unpublished changelog versions from `app/(home)/changelog/[version]/page.tsx` to the beta site on production, but the OG image route (`app/og/[...slug]/route.tsx`) and the LLM-text route (`app/llms.mdx/changelog/[[...slug]]/route.ts`) still 404 for the same versions.

This PR extracts the shared redirect-or-404 logic into `apps/docs/lib/beta-redirect.ts` (`notFoundOrBetaRedirect(path)`) and wires it into all three routes so unpublished changelog versions consistently 307 to the beta site on production instead of 404ing.

## Changes

- New: `apps/docs/lib/beta-redirect.ts` — shared helper, 307s to the beta site's copy of `path` on production, 404s elsewhere.
- `app/(home)/changelog/[version]/page.tsx` — uses the shared helper instead of its own local copy.
- `app/og/[...slug]/route.tsx` — changelog OG image case now falls back to the beta site's OG image.
- `app/llms.mdx/changelog/[[...slug]]/route.ts` — changelog LLM-text route now falls back to the beta site's LLM text.

## Verification

- `pnpm lint` — 0 warnings, 0 errors (also verifies types, per AGENTS.md).