### PR TITLE
Move Pandoc rendering to a typed AST boundary (spec #754)

### DIFF
--- a/apps/docs/content/docs/concepts/how-citekey-links-work.mdx
+++ b/apps/docs/content/docs/concepts/how-citekey-links-work.mdx
@@ -115,7 +115,7 @@ A copy holds the formatted entries only, in the style's bibliography order and w
 
 One copy writes two representations:
 
-- **Rich text** for an application that keeps formatting, such as Word or Google Docs. Emphasis, superscript, subscript, and small caps survive the paste.
+- **Rich text** for an application that keeps formatting, such as Word or Google Docs. Emphasis, strikethrough, superscript, subscript, and small caps survive the paste.
 - **Plain text** for an application that accepts text alone, with a blank line between entries.
 
 The destination takes the representation it supports. On a platform without rich clipboard support, ZotLit copies plain text and reports "Bibliography copied as plain text."

--- a/apps/docs/content/docs/reference/theme-hooks.mdx
+++ b/apps/docs/content/docs/reference/theme-hooks.mdx
@@ -16,6 +16,7 @@ This reference lists ZotLit's public citation CSS classes and their activation r
 | `zt-citation-key-unresolved`           | A citation key that does not resolve, or a rendered Citation in which no citation key resolves. The element also has `zt-citation-key`. |
 | `zt-citation-key-partially-unresolved` | A rendered Citation containing both resolved and unresolved citation keys. The element also has `zt-citation-key`.                      |
 | `zt-literature-note-link`              | A rendered Citation produced from a Literature Note link or Citation Run.                                                               |
+| `zt-entry-serial`                      | The Entry Serials of a rendered Citation, shown superscript in place of the footnote a note-class style writes.                         |
 
 A rendered Citation also has the class for its source. A literal Citation Cluster has `zt-citation` and `zt-citation-key`. A Citation Run made from Literature Note links has `zt-citation` and `zt-literature-note-link`.
 
@@ -48,11 +49,15 @@ A source also receives no public ZotLit class when both applicable features are 
 
 `zt-citation` appears only when ZotLit renders a Citation or supplies Citekey Navigation for it.
 
+`zt-entry-serial` appears inside a rendered Citation, on the element that holds its Entry Serials. ZotLit adds it only when the selected Citation and References Style writes the Citation as a footnote, which no Obsidian view can show. ZotLit then shows the position of each cited entry in the References Sidebar instead: one number per cited work, separated by commas, and `⚠` for a work the bibliography rendered no entry for. A style that writes its Citations inline — an author-date or a numeric style — activates this class nowhere.
+
 ## Default appearance [#defaults]
 
 Resolved citation keys use Obsidian's `--link-*` variables. Fully unresolved citation keys use the corresponding `--link-unresolved-*` variables.
 
 ZotLit adds no aggregate style for `zt-citation-key-partially-unresolved`. A partial result therefore keeps the appearance of its resolved works. ZotLit adds no style to a native Literature Note wikilink.
+
+ZotLit adds no style to `zt-entry-serial` either. The serials render as superscript text and take their appearance from the theme.
 
 ## CSS examples [#examples]
 
@@ -70,6 +75,10 @@ Use a direct class selector to override ZotLit's low-specificity defaults. `!imp
 
 .zt-literature-note-link {
   text-decoration-line: underline;
+}
+
+.zt-entry-serial {
+  color: var(--text-muted);
 }
 ```
 

--- a/apps/obsidian/CONTEXT.md
+++ b/apps/obsidian/CONTEXT.md
@@ -203,12 +203,20 @@ The default-on presentation choice that shows every recognized Citation as a Ren
 _Avoid_: citation rendering (ambiguous with reference rendering), citation display (does not say formatted or native), editor rendering (also applies to reading mode)
 
 **Document Citation Text**:
-The complete formatted text the Pandoc Engine produces for the Document Citation Set. It is produced for the whole document at once because a numbering style counts across the complete set, and every in-text surface changes from its native source presentation only after that complete result is ready. A Citation the engine cannot format stays entirely in its source presentation.
+The complete formatted text the Pandoc Engine produces for the Document Citation Set. It is produced for the whole document at once because a numbering style counts across the complete set and a position-dependent style renders each Citation Occurrence by its place in the document, so two occurrences of one source can read differently and each in-text surface shows the text of its own occurrence; a surface that cannot tell which occurrence it shows falls back to the source's first-occurrence text. Every in-text surface changes from its native source presentation only after that complete result is ready. A Citation the engine cannot format stays entirely in its source presentation.
 _Avoid_: citation cache (names the Citation Index's persistence, not this), rendered bibliography (the References Sidebar's whole-list render)
 
 **Citekey Navigation** _(Obsidian)_:
 The default-off interaction surface of recognized literal Pandoc citations across Live Preview, Source mode, and reading mode — selection, hover page preview, and the open-under-cursor palette commands — all routed through one flow. A single-item Citation opens its Literature Note; a multi-item Citation opens an item menu. It is independent of In-text Citation Rendering; Literature Note wikilinks keep Obsidian's native navigation.
 _Avoid_: citekey click (one gesture of the surface, not the concept), citekey links
+
+**Hover Action** _(Obsidian)_:
+The per-vault choice of what hovering a recognized citation or Literature Note wikilink shows: Off, Citation Popover (the default), or Page Preview. Off leaves Obsidian's native wikilink hover intact, and Citekey Navigation keeps selection and the open commands — never hover.
+_Avoid_: hover mode, popover toggle (a three-way choice, not an on/off)
+
+**Citation Popover** _(Obsidian)_:
+The concise hover popover that shows each cited entry's formatted bibliography text — full entries stacked unclipped for a multi-item Citation, formatted note text for a note-class marker — with the three action buttons per entry in a cursor-proximal row. It is one Hover Action choice; the native page preview is another, and hover never shows both.
+_Avoid_: concise popover (the working name), hover tooltip, hover card
 
 **Citekey Reading Rendering** _(Obsidian)_:
 The reading-mode surface of In-text Citation Rendering for literal Pandoc citations: a Markdown post-processor replaces each complete Citation the source writes — a Citation Cluster or a bare author-in-text key — with its formatted text. When any item in one Citation is unresolved, or the Pandoc Engine cannot supply its formatted text, that whole Citation stays unchanged. Code, math, and links are left alone; a Literature Note wikilink is the Wikilink Reading Rendering's surface, not this one's.

--- a/apps/obsidian/CONTEXT.md
+++ b/apps/obsidian/CONTEXT.md
@@ -119,7 +119,11 @@ _Avoid_: citation group (the group is the resulting Citation, not the source syn
 
 **Entry Marker**:
 The marker a numeric CSL style renders ahead of each bibliography entry — the entry's citation number wrapped in the style's own affixes, such as `[1]` or `1.`. It belongs to the Citation and References Style, not to ZotLit: a sorted style can give the same Item a different Entry Marker across renders, and a non-numeric style produces none.
-_Avoid_: serial number, reference index, gutter number
+_Avoid_: serial number, reference index, gutter number, Entry Serial (ZotLit's positional number, not the style's)
+
+**Entry Serial**:
+The 1-based position of a rendered entry in the References Sidebar's bibliography-ordered list — ZotLit-assigned and occurrence-independent, unlike the style-owned Entry Marker and the first-occurrence Reference Number. When a citation's formatted text contains a footnote the inline surfaces cannot render, the Entry Serial of each cited entry appears superscript in place of that footnote and in the sidebar gutter, an entry's own Entry Marker keeping precedence in the gutter.
+_Avoid_: serial number, footnote number (the document format's counter, which never renders here), fallback marker (names the mechanism, not the number)
 
 **Openable Attachment**:
 An Attachment of a cited Item whose path names a file, so Zotero's reader can be sent to it — the stored modes and both linked-file forms. A bare web link carries no file, and neither does a row whose path does not parse, so the References Sidebar offers neither. The file's format does not decide it: a PDF, an EPUB, a web snapshot, and an office document all qualify, and Zotero owns what happens to a format its reader cannot render.
@@ -127,7 +131,7 @@ _Avoid_: PDF attachment (the format is not the rule), openable file
 
 **Reference Number**:
 An active-document identifier assigned to each distinct Literature Note Citation by first occurrence. It appears in editor widgets and in the References Sidebar's minimal reference list when no engine renders; repeated Citations share the same number, and the Markdown source stays unchanged.
-_Avoid_: citation key, reference index
+_Avoid_: citation key, reference index, Entry Serial (bibliography-ordered, not first-occurrence)
 
 **Reference Error** _(Obsidian)_:
 A References Sidebar entry for an unresolved citation key, a missing Item, a malformed Citation Fragment while Wikilink Citations is on, or a source-backed Item omitted from a completed bibliography rendering.

--- a/apps/obsidian/src/lib/citation-fragment.ts
+++ b/apps/obsidian/src/lib/citation-fragment.ts
@@ -306,7 +306,7 @@ export interface CitationSource {
 /**
  * The Pandoc source text a standalone Citation or a whole Citation Run is
  * written as — the very text the equivalent Citation Cluster carries, so both
- * citing syntaxes reach one render and read alike.
+ * citing syntaxes reach one render.
  *
  * A run of several works is one bracketed cluster, which is also the only form
  * the citekey syntax can write a group in: an author-in-text item keeps its

--- a/apps/obsidian/src/lib/reading-view.ts
+++ b/apps/obsidian/src/lib/reading-view.ts
@@ -17,6 +17,7 @@ export interface SectionRange {
  * post-processor tell the Citation Occurrences it shows from the identical ones
  * written elsewhere in the same document.
  *
+ * @param ctx the post-processor context that section was rendered under.
  * @param el one rendered section, as a Markdown post-processor receives it.
  * @returns null when Obsidian places the section in no source range — an embed
  *   and a popover render outside one — which leaves the surface no coordinate.

--- a/apps/obsidian/src/lib/reading-view.ts
+++ b/apps/obsidian/src/lib/reading-view.ts
@@ -3,7 +3,49 @@
 // document has to ask the views to render that Markdown again.
 
 import { MarkdownView } from "obsidian";
-import type { App } from "obsidian";
+import type { App, MarkdownPostProcessorContext } from "obsidian";
+
+/** The document offsets one rendered reading-view section covers. */
+export interface SectionRange {
+  from: number;
+  /** One past the last offset, so the whole of the section's last line is in. */
+  to: number;
+}
+
+/**
+ * Where in its document one rendered section sits, which is what lets a
+ * post-processor tell the Citation Occurrences it shows from the identical ones
+ * written elsewhere in the same document.
+ *
+ * @param el one rendered section, as a Markdown post-processor receives it.
+ * @returns null when Obsidian places the section in no source range — an embed
+ *   and a popover render outside one — which leaves the surface no coordinate.
+ */
+export function sectionRange(
+  ctx: MarkdownPostProcessorContext,
+  el: HTMLElement,
+): SectionRange | null {
+  const info = ctx.getSectionInfo(el);
+  if (info === null) return null;
+  return {
+    from: lineStart(info.text, info.lineStart),
+    to: lineStart(info.text, info.lineEnd + 1),
+  };
+}
+
+/**
+ * @returns the offset line `line` starts at, or the end of `text` when it
+ *   writes fewer lines than that.
+ */
+function lineStart(text: string, line: number): number {
+  let offset = 0;
+  for (let index = 0; index < line; index += 1) {
+    const next = text.indexOf("\n", offset);
+    if (next === -1) return text.length;
+    offset = next + 1;
+  }
+  return offset;
+}
 
 /**
  * Renders every open reading view again, which is how a post-processor's output

--- a/apps/obsidian/src/lib/sanitize-html.ts
+++ b/apps/obsidian/src/lib/sanitize-html.ts
@@ -21,24 +21,3 @@ export function useSanitizedHtml<E extends HTMLElement>(html: string) {
     [html],
   );
 }
-
-/**
- * Renders an already-sanitized fragment into a DOM element React owns, for a
- * producer that parsed the markup once and kept it.
- *
- * Insertion moves nodes out of a fragment, so each write inserts a clone and
- * `content` stays reusable across re-renders.
- *
- * @param content Sanitized nodes to show.
- * @returns A ref callback to attach to the host element.
- */
-export function useDomContent<E extends HTMLElement>(
-  content: DocumentFragment,
-) {
-  return useCallback(
-    (el: E | null) => {
-      if (el) el.replaceChildren(content.cloneNode(true));
-    },
-    [content],
-  );
-}

--- a/apps/obsidian/src/lib/theme-hooks.ts
+++ b/apps/obsidian/src/lib/theme-hooks.ts
@@ -6,4 +6,5 @@ export const themeHook = {
   citationKeyUnresolved: "zt-citation-key-unresolved",
   citationKeyPartiallyUnresolved: "zt-citation-key-partially-unresolved",
   literatureNoteLink: "zt-literature-note-link",
+  entrySerial: "zt-entry-serial",
 } as const;

--- a/apps/obsidian/src/lib/wikilink-citation.test.ts
+++ b/apps/obsidian/src/lib/wikilink-citation.test.ts
@@ -160,6 +160,7 @@ describe("citationOfRun", () => {
     expect(citationOfRun([member(WANG_LINK)])).toEqual({
       source: "[@wang2020]",
       keys: expect.anything(),
+      works: [WANG.indexedKey],
     });
   });
 

--- a/apps/obsidian/src/lib/wikilink-citation.ts
+++ b/apps/obsidian/src/lib/wikilink-citation.ts
@@ -110,8 +110,27 @@ export interface RunMember<T> {
   citation: WikilinkCitation;
 }
 
-export function citationOfRun<T>(run: readonly RunMember<T>[]): CitationSource {
-  return citationRunSource(run.map(({ citation }) => citation.item));
+/**
+ * The Citation a whole run writes, with the work each of its keys names.
+ *
+ * A derived citekey is note text — an Item carrying no native citation key is
+ * named by its Literature Note's filename — so two Items can derive one
+ * spelling. The Indexed Keys are what identify the Citation.
+ *
+ * @see apps/obsidian/src/services/citation-text/present.ts — `HeldCitation`
+ */
+export interface RunCitationSource extends CitationSource {
+  /** {@link WikilinkCitation.indexedKey} of each of `keys`, in the same order. */
+  works: string[];
+}
+
+export function citationOfRun<T>(
+  run: readonly RunMember<T>[],
+): RunCitationSource {
+  return {
+    ...citationRunSource(run.map(({ citation }) => citation.item)),
+    works: run.map(({ citation }) => citation.indexedKey),
+  };
 }
 
 /**

--- a/apps/obsidian/src/services/citation-text/__fixtures__.ts
+++ b/apps/obsidian/src/services/citation-text/__fixtures__.ts
@@ -8,6 +8,8 @@ import type {
 import type { RenderedCitation } from "@/services/pandoc/engine";
 import { inlineText } from "@/services/pandoc/inline-content";
 
+import type { FormattedOccurrence } from "./present";
+
 /** The Indexed Key of the cited work, which is also the CSL id a render names it by. */
 export const ALPHA_KEY = "ALPHA234";
 
@@ -76,9 +78,30 @@ export function rendered(text: string): RenderedCitation {
   return { content: [{ t: "Str", c: text }], citations: [] };
 }
 
-/** The text one held citation reads as, which is what a suite asserts on. */
-export function renderedText(
-  citation: RenderedCitation | undefined,
+/**
+ * The one occurrence a document holding a Citation once writes of it, for a
+ * suite that stands in for a whole read.
+ */
+export function occurrence(
+  text: RenderedCitation,
+  start = 0,
+): FormattedOccurrence[] {
+  return [{ start, text }];
+}
+
+/**
+ * The text every occurrence of one held Citation reads as, in document order,
+ * which is what a suite asserting on a position-dependent render asserts on.
+ */
+export function occurrenceTexts(
+  occurrences: readonly FormattedOccurrence[] | undefined,
+): string[] {
+  return (occurrences ?? []).map(({ text }) => inlineText(text.content));
+}
+
+/** The text one held Citation's first occurrence reads as. */
+export function firstText(
+  occurrences: readonly FormattedOccurrence[] | undefined,
 ): string | undefined {
-  return citation && inlineText(citation.content);
+  return occurrenceTexts(occurrences)[0];
 }

--- a/apps/obsidian/src/services/citation-text/__fixtures__.ts
+++ b/apps/obsidian/src/services/citation-text/__fixtures__.ts
@@ -82,7 +82,7 @@ export function rendered(text: string): RenderedCitation {
  * The one occurrence a document holding a Citation once writes of it, for a
  * suite that stands in for a whole read.
  */
-export function occurrence(
+export function occurrences(
   text: RenderedCitation,
   start = 0,
 ): FormattedOccurrence[] {
@@ -94,14 +94,14 @@ export function occurrence(
  * which is what a suite asserting on a position-dependent render asserts on.
  */
 export function occurrenceTexts(
-  occurrences: readonly FormattedOccurrence[] | undefined,
+  held: readonly FormattedOccurrence[] = [],
 ): string[] {
-  return (occurrences ?? []).map(({ text }) => inlineText(text.content));
+  return held.map(({ text }) => inlineText(text.content));
 }
 
 /** The text one held Citation's first occurrence reads as. */
 export function firstText(
-  occurrences: readonly FormattedOccurrence[] | undefined,
+  held: readonly FormattedOccurrence[] = [],
 ): string | undefined {
-  return occurrenceTexts(occurrences)[0];
+  return occurrenceTexts(held)[0];
 }

--- a/apps/obsidian/src/services/citation-text/__fixtures__.ts
+++ b/apps/obsidian/src/services/citation-text/__fixtures__.ts
@@ -5,6 +5,8 @@ import type {
   Citation,
   CitationOccurrence,
 } from "@/services/citation-index/service";
+import type { RenderedCitation } from "@/services/pandoc/engine";
+import { inlineText } from "@/services/pandoc/inline-content";
 
 /** The Indexed Key of the cited work, which is also the CSL id a render names it by. */
 export const ALPHA_KEY = "ALPHA234";
@@ -70,8 +72,13 @@ export function literalOccurrences(body: string): CitationOccurrence[] {
 }
 
 /** One formatted citation, as the render cache hands it over. */
-export function fragment(text: string): DocumentFragment {
-  const content = document.createDocumentFragment();
-  content.append(text);
-  return content;
+export function rendered(text: string): RenderedCitation {
+  return { content: [{ t: "Str", c: text }], citations: [] };
+}
+
+/** The text one held citation reads as, which is what a suite asserts on. */
+export function renderedText(
+  citation: RenderedCitation | undefined,
+): string | undefined {
+  return citation && inlineText(citation.content);
 }

--- a/apps/obsidian/src/services/citation-text/__fixtures__.ts
+++ b/apps/obsidian/src/services/citation-text/__fixtures__.ts
@@ -6,7 +6,8 @@ import type {
   CitationOccurrence,
 } from "@/services/citation-index/service";
 
-export const ALPHA_KEY = "1/ALPHA123";
+/** The Indexed Key of the cited work, which is also the CSL id a render names it by. */
+export const ALPHA_KEY = "ALPHA234";
 
 /**
  * The Item the stubbed database answers with. A suite mocks `@zotlit/db` so

--- a/apps/obsidian/src/services/citation-text/__fixtures__.ts
+++ b/apps/obsidian/src/services/citation-text/__fixtures__.ts
@@ -8,7 +8,7 @@ import type {
 import type { RenderedCitation } from "@/services/pandoc/engine";
 import { inlineText } from "@/services/pandoc/inline-content";
 
-import type { FormattedOccurrence } from "./present";
+import type { FormattedOccurrence, PresentedCitation } from "./present";
 
 /** The Indexed Key of the cited work, which is also the CSL id a render names it by. */
 export const ALPHA_KEY = "ALPHA234";
@@ -78,6 +78,35 @@ export function rendered(text: string): RenderedCitation {
   return { content: [{ t: "Str", c: text }], citations: [] };
 }
 
+/** One formatted citation as a surface holds it, standing for no note. */
+export function presented(text: string): PresentedCitation {
+  return { text: rendered(text), serials: [] };
+}
+
+/**
+ * One formatted citation of a note-class style: the works it names read out of
+ * the source, and a note where an in-text style would have written the text.
+ *
+ * @param source the citation as the render was asked for it, whose keys are
+ *   the CSL ids the render answers with.
+ */
+export function noted(source: string): RenderedCitation {
+  return {
+    content: [
+      {
+        t: "Cite",
+        c: [
+          [],
+          [{ t: "Note", c: [{ t: "Para", c: [{ t: "Str", c: source }] }] }],
+        ],
+      },
+    ],
+    citations: scanDocumentCitations(source).flatMap(({ keys }) =>
+      keys.map(({ citekey }) => ({ id: citekey, mode: "normal" as const })),
+    ),
+  };
+}
+
 /**
  * The one occurrence a document holding a Citation once writes of it, for a
  * suite that stands in for a whole read.
@@ -86,7 +115,7 @@ export function occurrences(
   text: RenderedCitation,
   start = 0,
 ): FormattedOccurrence[] {
-  return [{ start, text }];
+  return [{ start, text, serials: [] }];
 }
 
 /**

--- a/apps/obsidian/src/services/citation-text/document-citation-set.integration.test.ts
+++ b/apps/obsidian/src/services/citation-text/document-citation-set.integration.test.ts
@@ -412,10 +412,10 @@ function openText(
     citationIndex: index,
     noteIndex,
     bibliographyRender: {
-      renderCitationsAst: (citations, items) =>
-        engine.renderCitationsAst({ citations, items, styleXml }),
-      renderAst: async (items) => {
-        const entries = await engine.renderBibliographyAst({ items, styleXml });
+      renderCitations: (citations, items) =>
+        engine.renderCitations({ citations, items, styleXml }),
+      render: async (items) => {
+        const entries = await engine.renderBibliography({ items, styleXml });
         return {
           kind: "rendered",
           entries,
@@ -441,7 +441,7 @@ async function sidebarEntries(
     const source = indexedKey && sources.get(indexedKey);
     return source ? [source.csl] : [];
   });
-  const bibliography = await engine.renderBibliographyAst({
+  const bibliography = await engine.renderBibliography({
     items,
     styleXml,
   });

--- a/apps/obsidian/src/services/citation-text/document-citation-set.integration.test.ts
+++ b/apps/obsidian/src/services/citation-text/document-citation-set.integration.test.ts
@@ -26,7 +26,7 @@ import { inlineText } from "@/services/pandoc/inline-content";
 import { buildReferenceEntries } from "@/views/references/entries";
 import type { ReferenceEntry } from "@/views/references/entries";
 
-import { ALPHA, renderedText } from "./__fixtures__";
+import { ALPHA, firstText } from "./__fixtures__";
 import { citationKey } from "./present";
 import { CitationText } from "./service";
 
@@ -173,16 +173,16 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
       "citekey",
     ]);
     expect(includedSet.citations[0]?.occurrences).toHaveLength(3);
-    expect(renderedText(includedText.formatted.get("@doe2024"))).toBe("[1]");
+    expect(firstText(includedText.formatted.get("@doe2024"))).toBe("[1]");
     expect(
-      renderedText(
+      firstText(
         includedText.formatted.get(
           citationKey({ source: "[@roe2025, p. 4]", works: [KEY_B] }),
         ),
       ),
     ).toBe("[2]");
     expect(
-      renderedText(
+      firstText(
         includedText.formatted.get(
           citationKey({ source: "[@doe2024]", works: [KEY_A] }),
         ),
@@ -200,7 +200,7 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
       "citekey",
     ]);
     expect(excludedSet.citations[0]?.occurrences).toHaveLength(2);
-    expect(renderedText(excludedText.formatted.get("@doe2024"))).toBe("[1]");
+    expect(firstText(excludedText.formatted.get("@doe2024"))).toBe("[1]");
     expect(
       excludedText.formatted.has(
         citationKey({ source: "[@roe2025, p. 4]", works: [KEY_B] }),
@@ -229,7 +229,7 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
     const entries = await sidebarEntries(engine, set.citations);
 
     expect(rendered.formatted.has("[@doe2024; @ghost]")).toBe(false);
-    expect(renderedText(rendered.formatted.get("@roe2025"))).toBe("[2]");
+    expect(firstText(rendered.formatted.get("@roe2025"))).toBe("[2]");
     expect(markers(entries)).toEqual(["[1]", "[2]", undefined]);
   });
 
@@ -256,12 +256,12 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
     const { formatted } = await text.load(harness.draft);
 
     expect(
-      renderedText(
+      firstText(
         formatted.get(citationKey({ source: "[@Draft]", works: [KEY_C] })),
       ),
     ).toBe("Cox");
     expect(
-      renderedText(
+      firstText(
         formatted.get(citationKey({ source: "[@Draft]", works: [KEY_D] })),
       ),
     ).toBe("Dey");
@@ -290,12 +290,12 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
     const { formatted } = await text.load(harness.draft);
 
     expect(
-      renderedText(
+      firstText(
         formatted.get(citationKey({ source: "[@Ess]", works: [KEY_E] })),
       ),
     ).toBe("[1]");
     expect(
-      renderedText(
+      firstText(
         formatted.get(citationKey({ source: "[@Ess2]", works: [KEY_E] })),
       ),
     ).toBe("[1]");
@@ -328,9 +328,9 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
     await harness.index.getDocumentCitationSet(harness.draft);
     const { formatted } = await text.load(harness.draft);
 
-    expect(renderedText(formatted.get("@doe2024"))).toBe("Zeta");
+    expect(firstText(formatted.get("@doe2024"))).toBe("Zeta");
     expect(
-      renderedText(
+      firstText(
         formatted.get(citationKey({ source: "[@doe2024]", works: [KEY_B] })),
       ),
     ).toBe("Roe");

--- a/apps/obsidian/src/services/citation-text/document-citation-set.integration.test.ts
+++ b/apps/obsidian/src/services/citation-text/document-citation-set.integration.test.ts
@@ -2,11 +2,12 @@
 import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
-import type { CachedMetadata } from "obsidian";
+import type { CachedMetadata, TFile } from "obsidian";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getItemsByKey, resolveIndexedKeyLibrary } from "@zotlit/db";
 
+import { FIELD_ZOTERO_KEY } from "@/lib/constants";
 import type {
   Citation,
   ReferenceSource,
@@ -16,7 +17,9 @@ import {
   KEY_A,
   KEY_B,
   link,
+  makeFile,
 } from "@/services/citation-index/test-harness";
+import type { CitationIndexHarness } from "@/services/citation-index/test-harness";
 import { createCitationEngine } from "@/services/pandoc/engine";
 import type {
   BibliographyEntry,
@@ -26,6 +29,7 @@ import { buildReferenceEntries } from "@/views/references/entries";
 import type { ReferenceEntry } from "@/views/references/entries";
 
 import { ALPHA } from "./__fixtures__";
+import { citationKey } from "./present";
 import { CitationText } from "./service";
 
 vi.mock("@zotlit/db", async (importOriginal) => {
@@ -64,29 +68,82 @@ const NUMERIC_STYLE = `<?xml version="1.0" encoding="utf-8"?>
   </bibliography>
 </style>`;
 
+/** Prints the author alone, so a rendered citation names the Item it came from. */
+const AUTHOR_STYLE = `<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0">
+  <info>
+    <title>Author integration</title>
+    <id>http://example.com/author-integration</id>
+    <updated>2020-01-01T00:00:00+00:00</updated>
+  </info>
+  <citation><layout><names variable="author"><name form="short"/></names></layout></citation>
+  <bibliography><layout><names variable="author"><name/></names></layout></bibliography>
+</style>`;
+
 const BODY =
   "@doe2024 then [[Roe 2025#cite:locator=4]] then [[Doe 2024]] then @doe2024.";
 
-const BETA = {
-  ...ALPHA,
-  key: "BETA2345",
-  itemID: 2,
-  indexedKey: KEY_B,
-  creators: [{ creatorType: "author", lastName: "Roe", firstName: "Bea" }],
-  fields: { ...ALPHA.fields, title: "Roe study", date: "2021" },
+/** The Indexed Keys of the keyless Items the collision suites cite. */
+const KEY_C = "CCCC2345";
+const KEY_D = "DDDD2345";
+const KEY_E = "EEEE2345";
+
+/** A personal-library Item, whose bare key is its Indexed Key. */
+function item(
+  indexedKey: string,
+  itemID: number,
+  family: string,
+): typeof ALPHA {
+  return {
+    ...ALPHA,
+    key: indexedKey,
+    itemID,
+    indexedKey,
+    creators: [{ creatorType: "author", lastName: family, firstName: "Bea" }],
+    fields: { ...ALPHA.fields, title: `${family} study`, date: "2021" },
+  };
+}
+
+/** Every Item the stubbed database answers with, by Indexed Key. */
+const ITEMS: Record<string, typeof ALPHA> = {
+  [KEY_A]: ALPHA,
+  [KEY_B]: item(KEY_B, 2, "Roe"),
+  [KEY_C]: item(KEY_C, 3, "Cox"),
+  [KEY_D]: item(KEY_D, 4, "Dey"),
+  [KEY_E]: item(KEY_E, 5, "Ess"),
 };
 
 beforeEach(() => {
   vi.mocked(resolveIndexedKeyLibrary).mockImplementation(
-    (_client, indexedKey) =>
-      indexedKey === KEY_A
-        ? { libraryID: 1, key: "ALPHA123" }
-        : { libraryID: 1, key: "BETA2345" },
+    (_client, indexedKey) => {
+      const found = ITEMS[indexedKey];
+      return found ? { libraryID: 1, key: found.key } : null;
+    },
   );
-  vi.mocked(getItemsByKey).mockImplementation((_client, _libraryID, keys) =>
-    keys[0] === "ALPHA123" ? [ALPHA as never] : [BETA as never],
-  );
+  vi.mocked(getItemsByKey).mockImplementation((_client, _libraryID, keys) => {
+    const found = Object.values(ITEMS).find(({ key }) => key === keys[0]);
+    return found ? [found as never] : [];
+  });
 });
+
+/**
+ * A Literature Note for an Item Zotero holds no citation key for, so the
+ * derived citekey falls back to the note's own filename.
+ */
+function addKeylessNote(
+  harness: CitationIndexHarness,
+  path: string,
+  indexedKey: string,
+): TFile {
+  const note = makeFile(path, "");
+  harness.metadataCache.files.set(path, note);
+  harness.vault.bodies.set(path, "");
+  harness.metadataCache.fileCache.set(path, {
+    frontmatter: { [FIELD_ZOTERO_KEY]: indexedKey },
+  } as CachedMetadata);
+  harness.noteIndex.notes.set(indexedKey, note);
+  return note;
+}
 
 describe("Document Citation Set integration", { timeout: 60_000 }, () => {
   it("keeps numeric in-text and sidebar assignments aligned across source changes", async () => {
@@ -94,8 +151,7 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
       { "draft.md": BODY },
       { settings: { "citation.wikilink-citations": true } },
     );
-    const { app, draft, index, metadataCache, noteIndex, settings, db } =
-      harness;
+    const { draft, index, metadataCache, settings } = harness;
     const fragmentOffset = BODY.indexOf("[[Roe");
     const fragmentlessOffset = BODY.indexOf("[[Doe");
     metadataCache.fileCache.set("draft.md", {
@@ -105,21 +161,7 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
       ],
     } as CachedMetadata);
     await using engine = await openEngine();
-    await using text = new CitationText({
-      app,
-      db,
-      citationIndex: index,
-      noteIndex,
-      bibliographyRender: {
-        renderCitations: (citations, items) =>
-          engine.renderCitations({
-            citations,
-            items,
-            styleXml: NUMERIC_STYLE,
-          }),
-        on: () => () => undefined,
-      },
-    });
+    await using text = openText(harness, engine, NUMERIC_STYLE);
     await text.ready;
 
     const includedSet = await index.getDocumentCitationSet(draft);
@@ -134,10 +176,16 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
     ]);
     expect(includedSet.citations[0]?.occurrences).toHaveLength(3);
     expect(includedText.formatted.get("@doe2024")?.textContent).toBe("[1]");
-    expect(includedText.formatted.get("[@roe2025, p. 4]")?.textContent).toBe(
-      "[2]",
-    );
-    expect(includedText.formatted.get("[@doe2024]")?.textContent).toBe("[1]");
+    expect(
+      includedText.formatted.get(
+        citationKey({ source: "[@roe2025, p. 4]", works: [KEY_B] }),
+      )?.textContent,
+    ).toBe("[2]");
+    expect(
+      includedText.formatted.get(
+        citationKey({ source: "[@doe2024]", works: [KEY_A] }),
+      )?.textContent,
+    ).toBe("[1]");
     expect(markers(includedEntries)).toEqual(["[1]", "[2]"]);
 
     settings.update({ "citation.wikilink-citations": false });
@@ -151,8 +199,16 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
     ]);
     expect(excludedSet.citations[0]?.occurrences).toHaveLength(2);
     expect(excludedText.formatted.get("@doe2024")?.textContent).toBe("[1]");
-    expect(excludedText.formatted.has("[@roe2025, p. 4]")).toBe(false);
-    expect(excludedText.formatted.has("[@doe2024]")).toBe(false);
+    expect(
+      excludedText.formatted.has(
+        citationKey({ source: "[@roe2025, p. 4]", works: [KEY_B] }),
+      ),
+    ).toBe(false);
+    expect(
+      excludedText.formatted.has(
+        citationKey({ source: "[@doe2024]", works: [KEY_A] }),
+      ),
+    ).toBe(false);
     expect(markers(excludedEntries)).toEqual(["[1]"]);
   });
 
@@ -161,23 +217,9 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
     await using harness = await createCitationIndexHarness({
       "draft.md": body,
     });
-    const { app, draft, index, noteIndex, db } = harness;
+    const { draft, index } = harness;
     await using engine = await openEngine();
-    await using text = new CitationText({
-      app,
-      db,
-      citationIndex: index,
-      noteIndex,
-      bibliographyRender: {
-        renderCitations: (citations, items) =>
-          engine.renderCitations({
-            citations,
-            items,
-            styleXml: NUMERIC_STYLE,
-          }),
-        on: () => () => undefined,
-      },
-    });
+    await using text = openText(harness, engine, NUMERIC_STYLE);
     await text.ready;
 
     const set = await index.getDocumentCitationSet(draft);
@@ -188,7 +230,124 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
     expect(rendered.formatted.get("@roe2025")?.textContent).toBe("[2]");
     expect(markers(entries)).toEqual(["[1]", "[2]", undefined]);
   });
+
+  // Two keyless Items whose Literature Notes share a filename derive one
+  // citekey, so a render keyed by that spelling shows one Item for both.
+  it("renders each work of a filename collision from its own Item", async () => {
+    const body = "First [[folder1/Draft]] then [[folder2/Draft]].";
+    await using harness = await createCitationIndexHarness(
+      { "draft.md": body },
+      { settings: { "citation.wikilink-citations": true } },
+    );
+    addKeylessNote(harness, "folder1/Draft.md", KEY_C);
+    addKeylessNote(harness, "folder2/Draft.md", KEY_D);
+    harness.metadataCache.fileCache.set("draft.md", {
+      links: [
+        link("folder1/Draft", body.indexOf("[[folder1")),
+        link("folder2/Draft", body.indexOf("[[folder2")),
+      ],
+    } as CachedMetadata);
+    await using engine = await openEngine();
+    await using text = openText(harness, engine, AUTHOR_STYLE);
+    await text.ready;
+
+    const { formatted } = await text.load(harness.draft);
+
+    expect(
+      formatted.get(citationKey({ source: "[@Draft]", works: [KEY_C] }))
+        ?.textContent,
+    ).toBe("Cox");
+    expect(
+      formatted.get(citationKey({ source: "[@Draft]", works: [KEY_D] }))
+        ?.textContent,
+    ).toBe("Dey");
+  });
+
+  // One keyless Item with two Literature Notes is spelled two ways, and a
+  // numbering style counts one physical source once however it is spelled.
+  it("numbers one work cited under two spellings once", async () => {
+    const body = "First [[Papers/Ess]] then [[Archive/Ess2]].";
+    await using harness = await createCitationIndexHarness(
+      { "draft.md": body },
+      { settings: { "citation.wikilink-citations": true } },
+    );
+    addKeylessNote(harness, "Papers/Ess.md", KEY_E);
+    addKeylessNote(harness, "Archive/Ess2.md", KEY_E);
+    harness.metadataCache.fileCache.set("draft.md", {
+      links: [
+        link("Papers/Ess", body.indexOf("[[Papers")),
+        link("Archive/Ess2", body.indexOf("[[Archive")),
+      ],
+    } as CachedMetadata);
+    await using engine = await openEngine();
+    await using text = openText(harness, engine, NUMERIC_STYLE);
+    await text.ready;
+
+    const { formatted } = await text.load(harness.draft);
+
+    expect(
+      formatted.get(citationKey({ source: "[@Ess]", works: [KEY_E] }))
+        ?.textContent,
+    ).toBe("[1]");
+    expect(
+      formatted.get(citationKey({ source: "[@Ess2]", works: [KEY_E] }))
+        ?.textContent,
+    ).toBe("[1]");
+  });
+
+  // Zotero holds no uniqueness rule for a citation key, and the resolution
+  // snapshot is first-wins, so a literal key reaches the winner while a
+  // wikilink to the loser still derives that same spelling.
+  it("renders a duplicate citation key from the Item each syntax reaches", async () => {
+    const body = "@doe2024 then [[Roe 2025]].";
+    await using harness = await createCitationIndexHarness(
+      { "draft.md": body },
+      {
+        settings: { "citation.wikilink-citations": true },
+        citekeys: [
+          { itemID: 1, key: "DOE2024", indexedKey: KEY_A, citekey: "doe2024" },
+          { itemID: 2, key: "ROE2025", indexedKey: KEY_B, citekey: "doe2024" },
+        ],
+      },
+    );
+    harness.metadataCache.fileCache.set("draft.md", {
+      links: [link("Roe 2025", body.indexOf("[["))],
+    } as CachedMetadata);
+    await using engine = await openEngine();
+    await using text = openText(harness, engine, AUTHOR_STYLE);
+    await text.ready;
+
+    // The first scan of a document announces itself, which drops a citation
+    // text read that raced it; the surfaces answer that by asking again.
+    await harness.index.getDocumentCitationSet(harness.draft);
+    const { formatted } = await text.load(harness.draft);
+
+    expect(formatted.get("@doe2024")?.textContent).toBe("Zeta");
+    expect(
+      formatted.get(citationKey({ source: "[@doe2024]", works: [KEY_B] }))
+        ?.textContent,
+    ).toBe("Roe");
+  });
 });
+
+/** One CitationText over a harness, formatting through the real engine. */
+function openText(
+  { app, db, index, noteIndex }: CitationIndexHarness,
+  engine: CitationEngine,
+  styleXml: string,
+): CitationText {
+  return new CitationText({
+    app,
+    db,
+    citationIndex: index,
+    noteIndex,
+    bibliographyRender: {
+      renderCitations: (citations, items) =>
+        engine.renderCitations({ citations, items, styleXml }),
+      on: () => () => undefined,
+    },
+  });
+}
 
 async function openEngine(): Promise<CitationEngine> {
   return createCitationEngine(await readFile(WASM_PATH));

--- a/apps/obsidian/src/services/citation-text/document-citation-set.integration.test.ts
+++ b/apps/obsidian/src/services/citation-text/document-citation-set.integration.test.ts
@@ -26,7 +26,7 @@ import { inlineText } from "@/services/pandoc/inline-content";
 import { buildReferenceEntries } from "@/views/references/entries";
 import type { ReferenceEntry } from "@/views/references/entries";
 
-import { ALPHA } from "./__fixtures__";
+import { ALPHA, renderedText } from "./__fixtures__";
 import { citationKey } from "./present";
 import { CitationText } from "./service";
 
@@ -173,16 +173,20 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
       "citekey",
     ]);
     expect(includedSet.citations[0]?.occurrences).toHaveLength(3);
-    expect(includedText.formatted.get("@doe2024")?.textContent).toBe("[1]");
+    expect(renderedText(includedText.formatted.get("@doe2024"))).toBe("[1]");
     expect(
-      includedText.formatted.get(
-        citationKey({ source: "[@roe2025, p. 4]", works: [KEY_B] }),
-      )?.textContent,
+      renderedText(
+        includedText.formatted.get(
+          citationKey({ source: "[@roe2025, p. 4]", works: [KEY_B] }),
+        ),
+      ),
     ).toBe("[2]");
     expect(
-      includedText.formatted.get(
-        citationKey({ source: "[@doe2024]", works: [KEY_A] }),
-      )?.textContent,
+      renderedText(
+        includedText.formatted.get(
+          citationKey({ source: "[@doe2024]", works: [KEY_A] }),
+        ),
+      ),
     ).toBe("[1]");
     expect(markers(includedEntries)).toEqual(["[1]", "[2]"]);
 
@@ -196,7 +200,7 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
       "citekey",
     ]);
     expect(excludedSet.citations[0]?.occurrences).toHaveLength(2);
-    expect(excludedText.formatted.get("@doe2024")?.textContent).toBe("[1]");
+    expect(renderedText(excludedText.formatted.get("@doe2024"))).toBe("[1]");
     expect(
       excludedText.formatted.has(
         citationKey({ source: "[@roe2025, p. 4]", works: [KEY_B] }),
@@ -225,7 +229,7 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
     const entries = await sidebarEntries(engine, set.citations);
 
     expect(rendered.formatted.has("[@doe2024; @ghost]")).toBe(false);
-    expect(rendered.formatted.get("@roe2025")?.textContent).toBe("[2]");
+    expect(renderedText(rendered.formatted.get("@roe2025"))).toBe("[2]");
     expect(markers(entries)).toEqual(["[1]", "[2]", undefined]);
   });
 
@@ -252,12 +256,14 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
     const { formatted } = await text.load(harness.draft);
 
     expect(
-      formatted.get(citationKey({ source: "[@Draft]", works: [KEY_C] }))
-        ?.textContent,
+      renderedText(
+        formatted.get(citationKey({ source: "[@Draft]", works: [KEY_C] })),
+      ),
     ).toBe("Cox");
     expect(
-      formatted.get(citationKey({ source: "[@Draft]", works: [KEY_D] }))
-        ?.textContent,
+      renderedText(
+        formatted.get(citationKey({ source: "[@Draft]", works: [KEY_D] })),
+      ),
     ).toBe("Dey");
   });
 
@@ -284,12 +290,14 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
     const { formatted } = await text.load(harness.draft);
 
     expect(
-      formatted.get(citationKey({ source: "[@Ess]", works: [KEY_E] }))
-        ?.textContent,
+      renderedText(
+        formatted.get(citationKey({ source: "[@Ess]", works: [KEY_E] })),
+      ),
     ).toBe("[1]");
     expect(
-      formatted.get(citationKey({ source: "[@Ess2]", works: [KEY_E] }))
-        ?.textContent,
+      renderedText(
+        formatted.get(citationKey({ source: "[@Ess2]", works: [KEY_E] })),
+      ),
     ).toBe("[1]");
   });
 
@@ -320,10 +328,11 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
     await harness.index.getDocumentCitationSet(harness.draft);
     const { formatted } = await text.load(harness.draft);
 
-    expect(formatted.get("@doe2024")?.textContent).toBe("Zeta");
+    expect(renderedText(formatted.get("@doe2024"))).toBe("Zeta");
     expect(
-      formatted.get(citationKey({ source: "[@doe2024]", works: [KEY_B] }))
-        ?.textContent,
+      renderedText(
+        formatted.get(citationKey({ source: "[@doe2024]", works: [KEY_B] })),
+      ),
     ).toBe("Roe");
   });
 });
@@ -340,8 +349,8 @@ function openText(
     citationIndex: index,
     noteIndex,
     bibliographyRender: {
-      renderCitations: (citations, items) =>
-        engine.renderCitations({ citations, items, styleXml }),
+      renderCitationsAst: (citations, items) =>
+        engine.renderCitationsAst({ citations, items, styleXml }),
       on: () => () => undefined,
     },
   });

--- a/apps/obsidian/src/services/citation-text/document-citation-set.integration.test.ts
+++ b/apps/obsidian/src/services/citation-text/document-citation-set.integration.test.ts
@@ -21,10 +21,8 @@ import {
 } from "@/services/citation-index/test-harness";
 import type { CitationIndexHarness } from "@/services/citation-index/test-harness";
 import { createCitationEngine } from "@/services/pandoc/engine";
-import type {
-  BibliographyEntry,
-  CitationEngine,
-} from "@/services/pandoc/engine";
+import type { CitationEngine } from "@/services/pandoc/engine";
+import { inlineText } from "@/services/pandoc/inline-content";
 import { buildReferenceEntries } from "@/views/references/entries";
 import type { ReferenceEntry } from "@/views/references/entries";
 
@@ -362,7 +360,7 @@ async function sidebarEntries(
     const source = indexedKey && sources.get(indexedKey);
     return source ? [source.csl] : [];
   });
-  const bibliography = await engine.renderBibliography({
+  const bibliography = await engine.renderBibliographyAst({
     items,
     styleXml: NUMERIC_STYLE,
   });
@@ -370,7 +368,7 @@ async function sidebarEntries(
     bibliography: {
       complete: true,
       entries: new Map(
-        bibliography.map(({ id, marker, content }: BibliographyEntry) => [
+        bibliography.map(({ id, marker, content }) => [
           id,
           { marker, content },
         ]),
@@ -408,6 +406,8 @@ function referenceSources(): ReadonlyMap<string, ReferenceSource> {
 
 function markers(entries: readonly ReferenceEntry[]): (string | undefined)[] {
   return entries.map((entry) =>
-    entry.kind === "rendered" ? entry.marker : undefined,
+    entry.kind === "rendered" && entry.marker
+      ? inlineText(entry.marker)
+      : undefined,
   );
 }

--- a/apps/obsidian/src/services/citation-text/document-citation-set.integration.test.ts
+++ b/apps/obsidian/src/services/citation-text/document-citation-set.integration.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getItemsByKey, resolveIndexedKeyLibrary } from "@zotlit/db";
 
 import { FIELD_ZOTERO_KEY } from "@/lib/constants";
+import { themeHook } from "@/lib/theme-hooks";
 import type {
   Citation,
   ReferenceSource,
@@ -27,7 +28,8 @@ import { buildReferenceEntries } from "@/views/references/entries";
 import type { ReferenceEntry } from "@/views/references/entries";
 
 import { ALPHA, firstText } from "./__fixtures__";
-import { citationKey } from "./present";
+import { citationElement, citationKey } from "./present";
+import type { FormattedOccurrence } from "./present";
 import { CitationText } from "./service";
 
 vi.mock("@zotlit/db", async (importOriginal) => {
@@ -76,6 +78,31 @@ const AUTHOR_STYLE = `<?xml version="1.0" encoding="utf-8"?>
   </info>
   <citation><layout><names variable="author"><name form="short"/></names></layout></citation>
   <bibliography><layout><names variable="author"><name/></names></layout></bibliography>
+</style>`;
+
+/**
+ * A note-class style: citeproc writes every citation as a footnote, which is
+ * the whole document no inline surface can show without Entry Serials.
+ */
+const NOTE_STYLE = `<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0">
+  <info>
+    <title>Note integration</title>
+    <id>http://example.com/note-integration</id>
+    <updated>2020-01-01T00:00:00+00:00</updated>
+  </info>
+  <citation>
+    <layout delimiter="; ">
+      <names variable="author"><name/></names>
+      <text variable="title" prefix=", " suffix="."/>
+    </layout>
+  </citation>
+  <bibliography>
+    <layout>
+      <names variable="author"><name/></names>
+      <text variable="title" prefix=". " suffix="."/>
+    </layout>
+  </bibliography>
 </style>`;
 
 const BODY =
@@ -212,6 +239,42 @@ describe("Document Citation Set integration", { timeout: 60_000 }, () => {
       ),
     ).toBe(false);
     expect(markers(excludedEntries)).toEqual(["[1]"]);
+  });
+
+  // The acceptance scenario of the whole rework: a note-class style shows its
+  // citations as Entry Serials inline and its full entries in the sidebar,
+  // with the digits inline and in the gutter reading the same.
+  it("shows a note-class style's citations as the serials its sidebar gutter repeats", async () => {
+    const body = "Both [@doe2024; @roe2025], then @roe2025 alone.";
+    await using harness = await createCitationIndexHarness({
+      "draft.md": body,
+    });
+    const { draft, index } = harness;
+    await using engine = await openEngine();
+    await using text = openText(harness, engine, NOTE_STYLE);
+    await text.ready;
+
+    const set = await index.getDocumentCitationSet(draft);
+    const rendered = await text.load(draft);
+    const entries = await sidebarEntries(engine, set.citations, NOTE_STYLE);
+
+    expect(rendered.entrySerials).toBe(true);
+    expect(serialRuns(rendered.formatted.get("[@doe2024; @roe2025]"))).toEqual([
+      "1,2",
+    ]);
+    expect(serialRuns(rendered.formatted.get("@roe2025"))).toEqual(["2"]);
+    // The sidebar shows the same works in the same order, each entry formatted
+    // in full, and its gutter carries the very digits the citations show.
+    expect(
+      entries.map((entry) =>
+        entry.kind === "rendered" ? entry.serial : undefined,
+      ),
+    ).toEqual([1, 2]);
+    expect(
+      entries.map((entry) =>
+        entry.kind === "rendered" ? inlineText(entry.content) : undefined,
+      ),
+    ).toEqual(["Doe. Doe study.", "Roe. Roe study."]);
   });
 
   it("keeps resolved items from a partial cluster in numeric context", async () => {
@@ -351,6 +414,14 @@ function openText(
     bibliographyRender: {
       renderCitationsAst: (citations, items) =>
         engine.renderCitationsAst({ citations, items, styleXml }),
+      renderAst: async (items) => {
+        const entries = await engine.renderBibliographyAst({ items, styleXml });
+        return {
+          kind: "rendered",
+          entries,
+          hasEntryMarkers: entries.some(({ marker }) => marker !== undefined),
+        };
+      },
       on: () => () => undefined,
     },
   });
@@ -363,6 +434,7 @@ async function openEngine(): Promise<CitationEngine> {
 async function sidebarEntries(
   engine: CitationEngine,
   citations: readonly Citation[],
+  styleXml: string = NUMERIC_STYLE,
 ): Promise<ReferenceEntry[]> {
   const sources = referenceSources();
   const items = citations.flatMap(({ indexedKey }) => {
@@ -371,7 +443,7 @@ async function sidebarEntries(
   });
   const bibliography = await engine.renderBibliographyAst({
     items,
-    styleXml: NUMERIC_STYLE,
+    styleXml,
   });
   return buildReferenceEntries(citations, sources, {
     bibliography: {
@@ -411,6 +483,22 @@ function referenceSources(): ReadonlyMap<string, ReferenceSource> {
     [KEY_A, source("doe2024", 1, "Doe")],
     [KEY_B, source("roe2025", 2, "Roe")],
   ]);
+}
+
+/**
+ * The Entry Serial run each occurrence of one held Citation shows, read off
+ * the element a surface inserts — the digits a reader sees, not the numbers
+ * behind them.
+ */
+function serialRuns(
+  held: readonly FormattedOccurrence[] = [],
+): (string | undefined)[] {
+  return held.map(
+    (occurrence) =>
+      citationElement(document, occurrence).querySelector(
+        `.${themeHook.entrySerial}`,
+      )?.textContent ?? undefined,
+  );
 }
 
 function markers(entries: readonly ReferenceEntry[]): (string | undefined)[] {

--- a/apps/obsidian/src/services/citation-text/present.test.ts
+++ b/apps/obsidian/src/services/citation-text/present.test.ts
@@ -3,8 +3,14 @@ import { describe, expect, it } from "vitest";
 
 import { scanCitations } from "@/lib/citation-grammar";
 
-import { citationContent, citationElement, citedWorks } from "./present";
-import type { CitationSource } from "./present";
+import { rendered } from "./__fixtures__";
+import {
+  citationContent,
+  citationElement,
+  citedWorks,
+  sectionCoordinates,
+} from "./present";
+import type { CitationSource, DocumentCitations } from "./present";
 
 /** One citation, read out of the source text that is nothing but that citation. */
 function citation(source: string): CitationSource {
@@ -63,6 +69,25 @@ describe("citedWorks", () => {
 });
 
 describe("citationContent", () => {
+  /**
+   * `First [@a]. Then [@a].` under a position-dependent style: the second
+   * occurrence of one source reads as the subsequent form citeproc gave it.
+   */
+  const HELD: DocumentCitations = {
+    formatted: new Map([
+      [
+        "[@a]",
+        [
+          { start: 6, text: rendered("(Zeta 2020)") },
+          { start: 20, text: rendered("(ibid.)") },
+        ],
+      ],
+    ]),
+    summaries: new Map([["ALPHA234", "Zeta (2020)"]]),
+    literalWorks: new Map([["a", "ALPHA234"]]),
+  };
+  const CITATION = citation("[@a]");
+
   it("keeps source presentation when no complete formatted result exists", () => {
     expect(
       citationContent(citation("[see @a, p. 3]"), {
@@ -71,6 +96,56 @@ describe("citationContent", () => {
         literalWorks: new Map([["a", "ALPHA234"]]),
       }),
     ).toBeNull();
+  });
+
+  it("shows the text of the occurrence an editor offset names", () => {
+    expect(
+      citationContent(CITATION, HELD, { kind: "offset", start: 20 })?.content,
+    ).toEqual(rendered("(ibid.)").content);
+  });
+
+  it("shows the text of the occurrence a section's own order names", () => {
+    expect(
+      citationContent(CITATION, HELD, {
+        kind: "section",
+        from: 14,
+        to: 25,
+        ordinal: 0,
+      })?.content,
+    ).toEqual(rendered("(ibid.)").content);
+  });
+
+  it("falls back to the first occurrence where a coordinate reaches none", () => {
+    // No coordinate at all, an offset an edit has moved, and a section counting
+    // one occurrence more than the document writes there.
+    for (const at of [
+      undefined,
+      { kind: "offset", start: 21 },
+      { kind: "section", from: 14, to: 25, ordinal: 1 },
+    ] as const) {
+      expect(citationContent(CITATION, HELD, at)?.content).toEqual(
+        rendered("(Zeta 2020)").content,
+      );
+    }
+  });
+});
+
+describe("sectionCoordinates", () => {
+  it("counts the occurrences of one identity the section shows, in its order", () => {
+    expect(
+      sectionCoordinates(
+        [citation("[@a]"), citation("[@b]"), citation("[@a]")],
+        { from: 14, to: 40 },
+      ),
+    ).toEqual([
+      { kind: "section", from: 14, to: 40, ordinal: 0 },
+      { kind: "section", from: 14, to: 40, ordinal: 0 },
+      { kind: "section", from: 14, to: 40, ordinal: 1 },
+    ]);
+  });
+
+  it("names no coordinate at all for a section Obsidian places nowhere", () => {
+    expect(sectionCoordinates([citation("[@a]")], null)).toEqual([undefined]);
   });
 });
 

--- a/apps/obsidian/src/services/citation-text/present.test.ts
+++ b/apps/obsidian/src/services/citation-text/present.test.ts
@@ -78,11 +78,12 @@ describe("citationContent", () => {
       [
         "[@a]",
         [
-          { start: 6, text: rendered("(Zeta 2020)") },
-          { start: 20, text: rendered("(ibid.)") },
+          { start: 6, text: rendered("(Zeta 2020)"), serials: [] },
+          { start: 20, text: rendered("(ibid.)"), serials: [] },
         ],
       ],
     ]),
+    entrySerials: false,
     summaries: new Map([["ALPHA234", "Zeta (2020)"]]),
     literalWorks: new Map([["a", "ALPHA234"]]),
   };
@@ -92,6 +93,7 @@ describe("citationContent", () => {
     expect(
       citationContent(citation("[see @a, p. 3]"), {
         formatted: new Map(),
+        entrySerials: false,
         summaries: new Map([["ALPHA234", "Zeta (2020)"]]),
         literalWorks: new Map([["a", "ALPHA234"]]),
       }),
@@ -100,7 +102,8 @@ describe("citationContent", () => {
 
   it("shows the text of the occurrence an editor offset names", () => {
     expect(
-      citationContent(CITATION, HELD, { kind: "offset", start: 20 })?.content,
+      citationContent(CITATION, HELD, { kind: "offset", start: 20 })?.text
+        .content,
     ).toEqual(rendered("(ibid.)").content);
   });
 
@@ -111,7 +114,7 @@ describe("citationContent", () => {
         from: 14,
         to: 25,
         ordinal: 0,
-      })?.content,
+      })?.text.content,
     ).toEqual(rendered("(ibid.)").content);
   });
 
@@ -123,7 +126,7 @@ describe("citationContent", () => {
       { kind: "offset", start: 21 },
       { kind: "section", from: 14, to: 25, ordinal: 1 },
     ] as const) {
-      expect(citationContent(CITATION, HELD, at)?.content).toEqual(
+      expect(citationContent(CITATION, HELD, at)?.text.content).toEqual(
         rendered("(Zeta 2020)").content,
       );
     }
@@ -158,12 +161,15 @@ describe("citationElement", () => {
 
   it("shows a formatted citation through the shared renderer", () => {
     const content = citationElement(document, {
-      content: [
-        { t: "Str", c: "Zeta" },
-        { t: "Space" },
-        { t: "Emph", c: [{ t: "Str", c: "(2020)" }] },
-      ],
-      citations: [],
+      text: {
+        content: [
+          { t: "Str", c: "Zeta" },
+          { t: "Space" },
+          { t: "Emph", c: [{ t: "Str", c: "(2020)" }] },
+        ],
+        citations: [],
+      },
+      serials: [],
     });
 
     expect(content.outerHTML).toBe(

--- a/apps/obsidian/src/services/citation-text/present.test.ts
+++ b/apps/obsidian/src/services/citation-text/present.test.ts
@@ -67,7 +67,8 @@ describe("citationContent", () => {
     expect(
       citationContent(citation("[see @a, p. 3]"), {
         formatted: new Map(),
-        summaries: new Map([["a", "Zeta (2020)"]]),
+        summaries: new Map([["ALPHA234", "Zeta (2020)"]]),
+        literalWorks: new Map([["a", "ALPHA234"]]),
       }),
     ).toBeNull();
   });

--- a/apps/obsidian/src/services/citation-text/present.test.ts
+++ b/apps/obsidian/src/services/citation-text/present.test.ts
@@ -75,9 +75,24 @@ describe("citationContent", () => {
 });
 
 describe("citationElement", () => {
-  it("wraps the formatted text in the class themes reach", () => {
+  it("wraps the source text in the class themes reach", () => {
     expect(citationElement(document, "Zeta (2020)").outerHTML).toBe(
       '<span class="zt-citation">Zeta (2020)</span>',
+    );
+  });
+
+  it("shows a formatted citation through the shared renderer", () => {
+    const content = citationElement(document, {
+      content: [
+        { t: "Str", c: "Zeta" },
+        { t: "Space" },
+        { t: "Emph", c: [{ t: "Str", c: "(2020)" }] },
+      ],
+      citations: [],
+    });
+
+    expect(content.outerHTML).toBe(
+      '<span class="zt-citation">Zeta <em>(2020)</em></span>',
     );
   });
 });

--- a/apps/obsidian/src/services/citation-text/present.ts
+++ b/apps/obsidian/src/services/citation-text/present.ts
@@ -3,6 +3,8 @@
 import type { CitationSource } from "@/lib/citation-fragment";
 import { themeHook } from "@/lib/theme-hooks";
 import type { CitedWork } from "@/services/citekey-navigation";
+import type { RenderedCitation } from "@/services/pandoc/engine";
+import { renderInlineContent } from "@/services/pandoc/inline-content";
 
 // One citation as a surface holds it: the same shape whether a note wrote it or
 // a wikilink derivation did, which is what lets the two syntaxes share a render.
@@ -39,7 +41,7 @@ export function citationKey({
 /** What one document's surfaces need to put text in their citations' place. */
 export interface DocumentCitations {
   /** The formatted citation of one {@link citationKey}, for every one the engine rendered. */
-  formatted: ReadonlyMap<string, DocumentFragment>;
+  formatted: ReadonlyMap<string, RenderedCitation>;
   /**
    * `Creators (Year)` by Indexed Key, used for navigation labels. A summary
    * belongs to the work, not to the citekey a document spells it with: one
@@ -115,29 +117,45 @@ export function citedWorks(
 export function citationContent(
   citation: HeldCitation,
   { formatted }: DocumentCitations,
-): DocumentFragment | string | null {
+): RenderedCitation | null {
   return formatted.get(citationKey(citation)) ?? null;
 }
 
 /**
- * A citation's content, ready for one surface to insert.
+ * Shows a citation's content in the element one surface inserts, replacing
+ * whatever that element held.
  *
- * Formatted content is shared with every other surface showing the same
- * citation, so a fragment goes in as a clone rather than being moved out of the
- * held text.
+ * A formatted citation is an immutable value every surface showing that
+ * citation holds at once, so each insertion shows it through the shared
+ * renderer rather than moving or copying one rendering between them.
+ *
+ * @param content the formatted citation, or the source text a surface shows
+ *   where no formatted text stands for it.
+ * @param links whether a link the style wrote becomes an anchor of its own. A
+ *   surface inserting into an anchor of Obsidian's suppresses them, since
+ *   nesting one anchor in another is invalid.
  */
-export function citationInsert(content: Node | string): Node | string {
-  return typeof content === "string" ? content : content.cloneNode(true);
+export function showCitation(
+  element: Element,
+  content: RenderedCitation | string,
+  links: "render" | "suppress" = "render",
+): void {
+  if (typeof content === "string") {
+    element.replaceChildren(content);
+    return;
+  }
+  element.replaceChildren();
+  renderInlineContent(element, { nodes: content.content, links });
 }
 
 /** Wraps a citation's content in the element a surface shows. */
 export function citationElement(
   doc: Document,
-  content: Node | string,
+  content: RenderedCitation | string,
   themeClasses: readonly string[] = [],
 ): HTMLElement {
   const element = doc.createElement("span");
   element.classList.add(themeHook.citation, ...themeClasses);
-  element.append(citationInsert(content));
+  showCitation(element, content);
   return element;
 }

--- a/apps/obsidian/src/services/citation-text/present.ts
+++ b/apps/obsidian/src/services/citation-text/present.ts
@@ -1,6 +1,7 @@
 // How one Citation is presented once its formatted text is known.
 
 import type { CitationSource } from "@/lib/citation-fragment";
+import type { SectionRange } from "@/lib/reading-view";
 import { themeHook } from "@/lib/theme-hooks";
 import type { CitedWork } from "@/services/citekey-navigation";
 import type { RenderedCitation } from "@/services/pandoc/engine";
@@ -38,10 +39,39 @@ export function citationKey({
   return works === undefined ? source : [source, ...works].join("\n");
 }
 
+/**
+ * One Citation Occurrence of a document, with the text the engine rendered for
+ * that occurrence.
+ */
+export interface FormattedOccurrence {
+  /** Offset the document writes the Citation at, which is the coordinate a surface matches. */
+  start: number;
+  text: RenderedCitation;
+}
+
+/**
+ * Which occurrence of a Citation one surface shows.
+ *
+ * An editor holds the document offset its decoration covers and matches the
+ * occurrence written there exactly. A reading view is placed by section alone,
+ * so it counts the occurrences of one identity that section shows and matches
+ * by that count.
+ */
+export type CitationCoordinate =
+  | { kind: "offset"; start: number }
+  | ({ kind: "section"; ordinal: number } & SectionRange);
+
 /** What one document's surfaces need to put text in their citations' place. */
 export interface DocumentCitations {
-  /** The formatted citation of one {@link citationKey}, for every one the engine rendered. */
-  formatted: ReadonlyMap<string, RenderedCitation>;
+  /**
+   * Every occurrence of one {@link citationKey} the engine rendered, in
+   * document order.
+   *
+   * A position-dependent style renders each Citation Occurrence by its place in
+   * the document, so two occurrences of one source can read differently and
+   * each surface shows the text of the occurrence it stands for.
+   */
+  formatted: ReadonlyMap<string, readonly FormattedOccurrence[]>;
   /**
    * `Creators (Year)` by Indexed Key, used for navigation labels. A summary
    * belongs to the work, not to the citekey a document spells it with: one
@@ -109,16 +139,60 @@ export function citedWorks(
 }
 
 /**
- * What one Citation shows: the text the engine formatted for its source.
+ * What one Citation shows: the text the engine formatted for the occurrence the
+ * surface holds.
  *
+ * @param at where the surface holds this occurrence. A surface with no
+ *   coordinate, and one whose coordinate reaches no occurrence — a section
+ *   Obsidian places nowhere, or an offset an edit has moved — shows the
+ *   source's first-occurrence text.
  * @returns `null` until a complete document render supplies this citation,
  *   which leaves its native source presentation unchanged.
  */
 export function citationContent(
   citation: HeldCitation,
   { formatted }: DocumentCitations,
+  at?: CitationCoordinate,
 ): RenderedCitation | null {
-  return formatted.get(citationKey(citation)) ?? null;
+  const occurrences = formatted.get(citationKey(citation));
+  if (occurrences === undefined) return null;
+  return (occurrenceAt(occurrences, at) ?? occurrences[0]!).text;
+}
+
+/** @returns the occurrence `at` names, or undefined when it names none of them. */
+function occurrenceAt(
+  occurrences: readonly FormattedOccurrence[],
+  at: CitationCoordinate | undefined,
+): FormattedOccurrence | undefined {
+  if (at === undefined) return undefined;
+  if (at.kind === "offset") {
+    return occurrences.find(({ start }) => start === at.start);
+  }
+  return occurrences.filter(({ start }) => start >= at.from && start < at.to)[
+    at.ordinal
+  ];
+}
+
+/**
+ * Where one rendered reading-view section holds each of its Citations, aligned
+ * with `citations` — which a post-processor reads in document order, so the
+ * occurrences of one identity are counted in the order the document writes them.
+ *
+ * @param section the offsets the section covers, or null when Obsidian places
+ *   it nowhere, which leaves every Citation there on first-occurrence text.
+ */
+export function sectionCoordinates(
+  citations: readonly HeldCitation[],
+  section: SectionRange | null,
+): (CitationCoordinate | undefined)[] {
+  if (section === null) return citations.map(() => undefined);
+  const counts = new Map<string, number>();
+  return citations.map((citation) => {
+    const identity = citationKey(citation);
+    const ordinal = counts.get(identity) ?? 0;
+    counts.set(identity, ordinal + 1);
+    return { kind: "section", ...section, ordinal };
+  });
 }
 
 /**

--- a/apps/obsidian/src/services/citation-text/present.ts
+++ b/apps/obsidian/src/services/citation-text/present.ts
@@ -40,13 +40,29 @@ export function citationKey({
 }
 
 /**
- * One Citation Occurrence of a document, with the text the engine rendered for
- * that occurrence.
+ * One Citation as a surface shows it: the text the engine rendered, and the
+ * Entry Serial standing for each work that text names.
  */
-export interface FormattedOccurrence {
+export interface PresentedCitation {
+  text: RenderedCitation;
+  /**
+   * One slot per work `text.citations` names, in the order it names them;
+   * `undefined` where the bibliography rendered no entry for that work.
+   *
+   * Empty for a document whose citations need no serial at all, which is every
+   * document an in-text style formats: with nothing for a note to stand for,
+   * the renderer drops the notes it meets rather than numbering them.
+   */
+  serials: readonly (number | undefined)[];
+}
+
+/**
+ * One Citation Occurrence of a document, as the surface showing that occurrence
+ * presents it.
+ */
+export interface FormattedOccurrence extends PresentedCitation {
   /** Offset the document writes the Citation at, which is the coordinate a surface matches. */
   start: number;
-  text: RenderedCitation;
 }
 
 /**
@@ -72,6 +88,12 @@ export interface DocumentCitations {
    * each surface shows the text of the occurrence it stands for.
    */
   formatted: ReadonlyMap<string, readonly FormattedOccurrence[]>;
+  /**
+   * Whether this document's citations stand for notes, so every surface shows
+   * Entry Serials in their place and the References Sidebar gutter shows the
+   * same digits. Read off what the engine rendered, not off the style.
+   */
+  entrySerials: boolean;
   /**
    * `Creators (Year)` by Indexed Key, used for navigation labels. A summary
    * belongs to the work, not to the citekey a document spells it with: one
@@ -153,10 +175,10 @@ export function citationContent(
   citation: HeldCitation,
   { formatted }: DocumentCitations,
   at?: CitationCoordinate,
-): RenderedCitation | null {
+): PresentedCitation | null {
   const occurrences = formatted.get(citationKey(citation));
   if (occurrences === undefined) return null;
-  return (occurrenceAt(occurrences, at) ?? occurrences[0]!).text;
+  return occurrenceAt(occurrences, at) ?? occurrences[0]!;
 }
 
 /** @returns the occurrence `at` names, or undefined when it names none of them. */
@@ -211,7 +233,7 @@ export function sectionCoordinates(
  */
 export function showCitation(
   element: Element,
-  content: RenderedCitation | string,
+  content: PresentedCitation | string,
   links: "render" | "suppress" = "render",
 ): void {
   if (typeof content === "string") {
@@ -219,13 +241,17 @@ export function showCitation(
     return;
   }
   element.replaceChildren();
-  renderInlineContent(element, { nodes: content.content, links });
+  renderInlineContent(element, {
+    nodes: content.text.content,
+    serials: content.serials,
+    links,
+  });
 }
 
 /** Wraps a citation's content in the element a surface shows. */
 export function citationElement(
   doc: Document,
-  content: RenderedCitation | string,
+  content: PresentedCitation | string,
   themeClasses: readonly string[] = [],
 ): HTMLElement {
   const element = doc.createElement("span");

--- a/apps/obsidian/src/services/citation-text/present.ts
+++ b/apps/obsidian/src/services/citation-text/present.ts
@@ -8,12 +8,52 @@ import type { CitedWork } from "@/services/citekey-navigation";
 // a wikilink derivation did, which is what lets the two syntaxes share a render.
 export type { CitationKey, CitationSource } from "@/lib/citation-fragment";
 
+/**
+ * One citation as a surface holds it, with the works it names when its own
+ * syntax cannot tell two citations apart without them.
+ *
+ * A literal citekey names one work: the citekey resolution snapshot decides
+ * what a spelling reaches, so every occurrence of that spelling reaches the
+ * same Item and the source alone identifies the citation. A wikilink derivation
+ * names its works itself, because two Items can derive the same citekey text.
+ */
+export interface HeldCitation extends CitationSource {
+  /** Indexed Key of each of `keys`, or absent when the source alone identifies. */
+  works?: readonly string[];
+}
+
+/**
+ * The identity one formatted citation is held under — the source a surface
+ * shows, and the works it names when the surface names them.
+ *
+ * Neither a Pandoc source of one citation nor an Indexed Key carries a line
+ * break, so the join is unambiguous.
+ */
+export function citationKey({
+  source,
+  works,
+}: Pick<HeldCitation, "source" | "works">): string {
+  return works === undefined ? source : [source, ...works].join("\n");
+}
+
 /** What one document's surfaces need to put text in their citations' place. */
 export interface DocumentCitations {
-  /** The formatted citation of one source, for every source the engine rendered. */
+  /** The formatted citation of one {@link citationKey}, for every one the engine rendered. */
   formatted: ReadonlyMap<string, DocumentFragment>;
-  /** `Creators (Year)` by citekey, used for navigation labels. */
+  /**
+   * `Creators (Year)` by Indexed Key, used for navigation labels. A summary
+   * belongs to the work, not to the citekey a document spells it with: one
+   * spelling can name two works, so a surface joins through the identity its
+   * own syntax knows.
+   */
   summaries: ReadonlyMap<string, string>;
+  /**
+   * The Item each literal citekey of the document names, which is the join a
+   * literal surface reaches a summary through. A derived citekey is left out —
+   * a wikilink surface names its works itself, and letting a derivation claim a
+   * spelling would answer for a literal key that reaches nothing.
+   */
+  literalWorks: ReadonlyMap<string, string>;
 }
 
 /**
@@ -21,6 +61,28 @@ export interface DocumentCitations {
  * reaches no Zotero Item.
  */
 export type SummaryOf = (citekey: string) => string | undefined;
+
+/** {@link SummaryOf} for the literal citekeys one document writes. */
+export function literalSummaryOf({
+  summaries,
+  literalWorks,
+}: DocumentCitations): SummaryOf {
+  return (citekey) => {
+    const indexedKey = literalWorks.get(citekey);
+    return indexedKey === undefined ? undefined : summaries.get(indexedKey);
+  };
+}
+
+/**
+ * How many of one citation's keys reach no Zotero Item, which is what decides
+ * between the resolved, partly unresolved, and wholly unresolved theme hooks.
+ */
+export function unresolvedKeys(
+  { keys }: CitationSource,
+  summaryOf: SummaryOf,
+): number {
+  return keys.filter((key) => summaryOf(key.citekey) === undefined).length;
+}
 
 /**
  * The works one rendered citation names, in the order it names them.
@@ -51,10 +113,10 @@ export function citedWorks(
  *   which leaves its native source presentation unchanged.
  */
 export function citationContent(
-  citation: CitationSource,
+  citation: HeldCitation,
   { formatted }: DocumentCitations,
 ): DocumentFragment | string | null {
-  return formatted.get(citation.source) ?? null;
+  return formatted.get(citationKey(citation)) ?? null;
 }
 
 /**

--- a/apps/obsidian/src/services/citation-text/service.test.ts
+++ b/apps/obsidian/src/services/citation-text/service.test.ts
@@ -19,6 +19,7 @@ import {
   fragment,
   literalOccurrences,
 } from "./__fixtures__";
+import { citationKey, literalSummaryOf } from "./present";
 import { CitationText } from "./service";
 
 vi.mock("@zotlit/db", async (importOriginal) => {
@@ -40,10 +41,10 @@ vi.mock("@zotlit/db", async (importOriginal) => {
 const NOTE = { path: "note.md" } as TFile;
 
 /**
- * The Indexed Key a Literature Note stand-in carries. Zotero's item-key charset
- * leaves out `1`, so the fixture Item's own key cannot stand in for one.
+ * The Indexed Key a Literature Note stand-in carries. It names an Item of its
+ * own, so a wikilink and a literal citekey are told apart by what they reach.
  */
-const LIT_KEY = "ALPHA234";
+const LIT_KEY = "BETA5678";
 
 interface Harness {
   service: CitationText;
@@ -196,10 +197,10 @@ describe("CitationText", () => {
     const { formatted } = await service.load(NOTE);
 
     expect(citationRequests).toEqual([
-      { citations: ["@alpha", "[see @alpha, p. 3]"] },
+      { citations: [`@${ALPHA_KEY}`, `[see @${ALPHA_KEY}, p. 3]`] },
     ]);
     expect(formatted.get("[see @alpha, p. 3]")?.textContent).toBe(
-      "«[see @alpha, p. 3]»",
+      `«[see @${ALPHA_KEY}, p. 3]»`,
     );
     await dispose();
   });
@@ -211,7 +212,7 @@ describe("CitationText", () => {
 
     await service.load(NOTE);
 
-    expect(citationRequests).toEqual([{ citations: ["[@alpha]"] }]);
+    expect(citationRequests).toEqual([{ citations: [`[@${ALPHA_KEY}]`] }]);
     await dispose();
   });
 
@@ -233,10 +234,10 @@ describe("CitationText", () => {
       formats: false,
     });
 
-    const { formatted, summaries } = await service.load(NOTE);
+    const text = await service.load(NOTE);
 
-    expect(summaries.get("alpha")).toBe("Zeta (2020)");
-    expect(formatted.size).toBe(0);
+    expect(literalSummaryOf(text)("alpha")).toBe("Zeta (2020)");
+    expect(text.formatted.size).toBe(0);
     await dispose();
   });
 
@@ -261,9 +262,11 @@ describe("CitationText", () => {
 
     const { formatted } = await service.load(NOTE);
 
-    expect(citationRequests).toEqual([{ citations: ["[@alpha]", "[@alpha]"] }]);
+    expect(citationRequests).toEqual([
+      { citations: [`[@${ALPHA_KEY}]`, `[@${ALPHA_KEY}]`] },
+    ]);
     expect(formatted.has("[@alpha; @ghost]")).toBe(false);
-    expect(formatted.get("[@alpha]")?.textContent).toBe("«[@alpha]»");
+    expect(formatted.get("[@alpha]")?.textContent).toBe(`«[@${ALPHA_KEY}]»`);
     await dispose();
   });
 
@@ -314,10 +317,11 @@ describe("CitationText over wikilink Citations", () => {
 
     const { formatted } = await service.load(NOTE);
 
-    expect(citationRequests).toEqual([{ citations: ["[@alpha, p. 4]"] }]);
-    expect(formatted.get("[@alpha, p. 4]")?.textContent).toBe(
-      "«[@alpha, p. 4]»",
-    );
+    expect(citationRequests).toEqual([{ citations: [`[@${LIT_KEY}, p. 4]`] }]);
+    expect(
+      formatted.get(citationKey({ source: "[@alpha, p. 4]", works: [LIT_KEY] }))
+        ?.textContent,
+    ).toBe(`«[@${LIT_KEY}, p. 4]»`);
     await dispose();
   });
 
@@ -338,7 +342,7 @@ describe("CitationText over wikilink Citations", () => {
     await service.load(NOTE);
 
     expect(citationRequests).toEqual([
-      { citations: ["[@alpha, p. 4; @alpha]"] },
+      { citations: [`[@${LIT_KEY}, p. 4; @${LIT_KEY}]`] },
     ]);
     await dispose();
   });
@@ -374,7 +378,7 @@ describe("CitationText over wikilink Citations", () => {
 
     await service.load(NOTE);
 
-    expect(citationRequests).toEqual([{ citations: ["[@alpha]"] }]);
+    expect(citationRequests).toEqual([{ citations: [`[@${LIT_KEY}]`] }]);
     await dispose();
   });
 
@@ -405,7 +409,7 @@ describe("CitationText over wikilink Citations", () => {
     await service.load(NOTE);
 
     expect(citationRequests).toEqual([
-      { citations: ["[@alpha, p. 5]", "[@alpha, p. 6]"] },
+      { citations: [`[@${LIT_KEY}, p. 5]`, `[@${ALPHA_KEY}, p. 6]`] },
     ]);
     await dispose();
   });
@@ -429,7 +433,7 @@ describe("CitationText over wikilink Citations", () => {
     await dispose();
   });
 
-  it("names a wikilink-cited work by its native Zotero citation key", async () => {
+  it("summarizes a wikilink-cited work under the Item it names", async () => {
     const body = `Claim [[${LIT}]].`;
     const { service, dispose } = await makeHarness({
       body,
@@ -442,7 +446,27 @@ describe("CitationText over wikilink Citations", () => {
 
     const { summaries } = await service.load(NOTE);
 
-    expect(summaries.get("alpha")).toBe("Zeta (2020)");
+    expect(summaries.get(LIT_KEY)).toBe("Zeta (2020)");
+    await dispose();
+  });
+
+  // A wikilink names its own works, so its citekey must not answer for a
+  // literal key of the same spelling that reaches no Item at all.
+  it("keeps a derived citekey out of the literal join", async () => {
+    const body = `Claim [[${LIT}]], and @alpha reaches nothing.`;
+    const { service, dispose } = await makeHarness({
+      body,
+      cited: [citation("alpha", null)],
+      links: [link(LIT, body.indexOf("[["))],
+      notes,
+      settings: WIKILINK_CITATIONS,
+      formats: false,
+    });
+
+    const text = await service.load(NOTE);
+
+    expect(text.summaries.get(LIT_KEY)).toBe("Zeta (2020)");
+    expect(literalSummaryOf(text)("alpha")).toBeUndefined();
     await dispose();
   });
 });

--- a/apps/obsidian/src/services/citation-text/service.test.ts
+++ b/apps/obsidian/src/services/citation-text/service.test.ts
@@ -9,6 +9,7 @@ import type {
   CitationOccurrence,
   DocumentCitationSet,
 } from "@/services/citation-index/service";
+import type { RenderedCitation } from "@/services/pandoc/engine";
 import { defaults } from "@/services/settings/schema";
 import type { Settings } from "@/services/settings/schema";
 
@@ -16,8 +17,9 @@ import {
   ALPHA,
   ALPHA_KEY,
   citation,
-  fragment,
   literalOccurrences,
+  rendered,
+  renderedText,
 } from "./__fixtures__";
 import { citationKey, literalSummaryOf } from "./present";
 import { CitationText } from "./service";
@@ -79,7 +81,7 @@ async function makeHarness({
   /** A render-cache answer used when a test needs generation control. */
   formatCitations?: (
     citations: readonly string[],
-  ) => Promise<readonly DocumentFragment[] | null>;
+  ) => Promise<readonly RenderedCitation[] | null>;
   /** The wikilinks Obsidian's metadata cache reports for the document. */
   links?: LinkCache[];
   /** The Literature Note each linkpath names, by linkpath. */
@@ -149,11 +151,11 @@ async function makeHarness({
       whenIndexed: () => Promise.resolve(),
     },
     bibliographyRender: {
-      renderCitations: (citations: readonly string[]) => {
+      renderCitationsAst: (citations: readonly string[]) => {
         citationRequests.push({ citations });
         if (formatCitations) return formatCitations(citations);
         return Promise.resolve(
-          formats ? citations.map((source) => fragment(`«${source}»`)) : null,
+          formats ? citations.map((source) => rendered(`«${source}»`)) : null,
         );
       },
       on: listen("render"),
@@ -199,7 +201,7 @@ describe("CitationText", () => {
     expect(citationRequests).toEqual([
       { citations: [`@${ALPHA_KEY}`, `[see @${ALPHA_KEY}, p. 3]`] },
     ]);
-    expect(formatted.get("[see @alpha, p. 3]")?.textContent).toBe(
+    expect(renderedText(formatted.get("[see @alpha, p. 3]"))).toBe(
       `«[see @${ALPHA_KEY}, p. 3]»`,
     );
     await dispose();
@@ -266,14 +268,14 @@ describe("CitationText", () => {
       { citations: [`[@${ALPHA_KEY}]`, `[@${ALPHA_KEY}]`] },
     ]);
     expect(formatted.has("[@alpha; @ghost]")).toBe(false);
-    expect(formatted.get("[@alpha]")?.textContent).toBe(`«[@${ALPHA_KEY}]»`);
+    expect(renderedText(formatted.get("[@alpha]"))).toBe(`«[@${ALPHA_KEY}]»`);
     await dispose();
   });
 
   it("withholds a generation whose render result is incomplete", async () => {
     const { service, dispose } = await makeHarness({
       body: "First [@alpha], then [see @alpha, p. 3].",
-      formatCitations: async ([first]) => [fragment(`«${first}»`)],
+      formatCitations: async ([first]) => [rendered(`«${first}»`)],
     });
 
     const { formatted } = await service.load(NOTE);
@@ -319,8 +321,11 @@ describe("CitationText over wikilink Citations", () => {
 
     expect(citationRequests).toEqual([{ citations: [`[@${LIT_KEY}, p. 4]`] }]);
     expect(
-      formatted.get(citationKey({ source: "[@alpha, p. 4]", works: [LIT_KEY] }))
-        ?.textContent,
+      renderedText(
+        formatted.get(
+          citationKey({ source: "[@alpha, p. 4]", works: [LIT_KEY] }),
+        ),
+      ),
     ).toBe(`«[@${LIT_KEY}, p. 4]»`);
     await dispose();
   });
@@ -473,7 +478,7 @@ describe("CitationText over wikilink Citations", () => {
 
 describe("CitationText staleness", () => {
   it("does not publish a generation superseded while its render was running", async () => {
-    let finishFirst: ((value: readonly DocumentFragment[]) => void) | undefined;
+    let finishFirst: ((value: readonly RenderedCitation[]) => void) | undefined;
     let generation = 0;
     const { service, citationRequests, indexChanged, dispose } =
       await makeHarness({
@@ -485,7 +490,7 @@ describe("CitationText staleness", () => {
               finishFirst = resolve;
             });
           }
-          return [fragment("fresh")];
+          return [rendered("fresh")];
         },
       });
 
@@ -494,12 +499,12 @@ describe("CitationText staleness", () => {
     indexChanged(NOTE.path);
     const current = service.load(NOTE);
     await vi.waitFor(() => expect(citationRequests).toHaveLength(2));
-    finishFirst?.([fragment("stale")]);
+    finishFirst?.([rendered("stale")]);
 
-    expect((await superseded).formatted.get("[@alpha]")?.textContent).toBe(
+    expect(renderedText((await superseded).formatted.get("[@alpha]"))).toBe(
       "fresh",
     );
-    expect((await current).formatted.get("[@alpha]")?.textContent).toBe(
+    expect(renderedText((await current).formatted.get("[@alpha]"))).toBe(
       "fresh",
     );
     await dispose();

--- a/apps/obsidian/src/services/citation-text/service.test.ts
+++ b/apps/obsidian/src/services/citation-text/service.test.ts
@@ -164,14 +164,14 @@ async function makeHarness({
       whenIndexed: () => Promise.resolve(),
     },
     bibliographyRender: {
-      renderCitationsAst: (citations: readonly string[]) => {
+      renderCitations: (citations: readonly string[]) => {
         citationRequests.push({ citations });
         if (formatCitations) return formatCitations(citations);
         return Promise.resolve(
           formats ? citations.map((source) => rendered(`«${source}»`)) : null,
         );
       },
-      renderAst: (items: readonly { id: string }[]) => {
+      render: (items: readonly { id: string }[]) => {
         const ids = items.map(({ id }) => id);
         bibliographyRequests.push(ids);
         const entries = bibliography ? bibliography(ids) : ids;

--- a/apps/obsidian/src/services/citation-text/service.test.ts
+++ b/apps/obsidian/src/services/citation-text/service.test.ts
@@ -19,10 +19,12 @@ import {
   citation,
   firstText,
   literalOccurrences,
+  noted,
   occurrenceTexts,
   rendered,
 } from "./__fixtures__";
 import { citationKey, literalSummaryOf } from "./present";
+import type { FormattedOccurrence } from "./present";
 import { CitationText } from "./service";
 
 vi.mock("@zotlit/db", async (importOriginal) => {
@@ -52,6 +54,8 @@ const LIT_KEY = "BETA5678";
 interface Harness {
   service: CitationText;
   citationRequests: { citations: readonly string[] }[];
+  /** The CSL ids of every bibliography render the read asked for, in order. */
+  bibliographyRequests: string[][];
   /** Fires the Citation Index's own event for one document. */
   indexChanged: (path: string) => void;
   /** Fires the render cache's wholesale drop. */
@@ -70,6 +74,7 @@ async function makeHarness({
   cited = [citation("alpha", ALPHA_KEY)],
   formats = true,
   formatCitations,
+  bibliography,
   links = [],
   notes = {},
   settings = {},
@@ -83,6 +88,12 @@ async function makeHarness({
   formatCitations?: (
     citations: readonly string[],
   ) => Promise<readonly RenderedCitation[] | null>;
+  /**
+   * The works the bibliography renders an entry for, in bibliography order,
+   * out of the works it was asked for. Defaults to all of them in that same
+   * order; `null` for a render that cannot answer at all.
+   */
+  bibliography?: (ids: readonly string[]) => readonly string[] | null;
   /** The wikilinks Obsidian's metadata cache reports for the document. */
   links?: LinkCache[];
   /** The Literature Note each linkpath names, by linkpath. */
@@ -91,6 +102,7 @@ async function makeHarness({
   documentCitationSet?: DocumentCitationSet;
 }): Promise<Harness> {
   const citationRequests: { citations: readonly string[] }[] = [];
+  const bibliographyRequests: string[][] = [];
   const listeners = new Map<string, (payload?: never) => void>();
   const listen =
     (event: string) =>
@@ -159,6 +171,24 @@ async function makeHarness({
           formats ? citations.map((source) => rendered(`«${source}»`)) : null,
         );
       },
+      renderAst: (items: readonly { id: string }[]) => {
+        const ids = items.map(({ id }) => id);
+        bibliographyRequests.push(ids);
+        const entries = bibliography ? bibliography(ids) : ids;
+        return Promise.resolve(
+          entries === null
+            ? { kind: "failed" }
+            : {
+                kind: "rendered",
+                entries: entries.map((id) => ({
+                  id,
+                  marker: undefined,
+                  content: [],
+                })),
+                hasEntryMarkers: false,
+              },
+        );
+      },
       on: listen("render"),
     },
     settings: {
@@ -174,6 +204,7 @@ async function makeHarness({
   return {
     service,
     citationRequests,
+    bibliographyRequests,
     indexChanged: (path) => fire("index:changed", path),
     rendersInvalidated: () => fire("render:invalidated"),
     resolutionChanged: () => fire("notes:changed"),
@@ -656,6 +687,133 @@ describe("CitationText staleness", () => {
 
     expect(citationRequests).toHaveLength(2);
     expect(service.peek(NOTE.path)).not.toBeNull();
+    await dispose();
+  });
+});
+
+/**
+ * The Entry Serial standing for each work of one held Citation's first
+ * occurrence.
+ */
+function firstSerials(
+  held: readonly FormattedOccurrence[] = [],
+): readonly (number | undefined)[] | undefined {
+  return held[0]?.serials;
+}
+
+/**
+ * Two Items, so a cluster names two works the bibliography numbers apart. Every
+ * other suite reads one Item for whatever Indexed Key it asks about.
+ */
+function readTwoItems(): void {
+  vi.mocked(resolveIndexedKeyLibrary).mockImplementation(
+    (_client, indexedKey) => ({
+      libraryID: 1,
+      key: indexedKey === LIT_KEY ? "BETA123" : "ALPHA123",
+    }),
+  );
+  vi.mocked(getItemsByKey).mockImplementation((_client, _libraryID, keys) => [
+    { ...ALPHA, key: keys[0] } as never,
+  ]);
+}
+
+describe("CitationText Entry Serials", () => {
+  /** `Both [@alpha; @beta].` under a style whose citations are footnotes. */
+  const CLUSTER = "[@alpha; @beta]";
+  const TWO_WORKS = [citation("alpha", ALPHA_KEY), citation("beta", LIT_KEY)];
+
+  beforeEach(() => {
+    readTwoItems();
+  });
+
+  it("stands one serial per cited work in for the note a style writes", async () => {
+    const { service, bibliographyRequests, dispose } = await makeHarness({
+      body: `Both ${CLUSTER}.`,
+      cited: TWO_WORKS,
+      formatCitations: (sources) => Promise.resolve(sources.map(noted)),
+    });
+
+    const { formatted, entrySerials } = await service.load(NOTE);
+
+    expect(entrySerials).toBe(true);
+    expect(firstSerials(formatted.get(CLUSTER))).toEqual([1, 2]);
+    // The bibliography is read for the works the document cites, in the order
+    // the References Sidebar lists them.
+    expect(bibliographyRequests).toHaveLength(1);
+    await dispose();
+  });
+
+  // Author-in-text and author-suppressed members are the same works in the
+  // same order, so the digits they show are the same digits.
+  it("numbers the works of a citation however it names them", async () => {
+    const { service, dispose } = await makeHarness({
+      body: `Both ${CLUSTER}.`,
+      cited: TWO_WORKS,
+      formatCitations: () =>
+        Promise.resolve([
+          {
+            ...noted(`[@${ALPHA_KEY}; @${LIT_KEY}]`),
+            citations: [
+              { id: ALPHA_KEY, mode: "author-in-text" as const },
+              { id: LIT_KEY, mode: "suppress-author" as const },
+            ],
+          },
+        ]),
+    });
+
+    const { formatted } = await service.load(NOTE);
+
+    expect(firstSerials(formatted.get(CLUSTER))).toEqual([1, 2]);
+    await dispose();
+  });
+
+  it("leaves the slot of a work the bibliography left out empty", async () => {
+    const { service, dispose } = await makeHarness({
+      body: `Both ${CLUSTER}.`,
+      cited: TWO_WORKS,
+      formatCitations: (sources) => Promise.resolve(sources.map(noted)),
+      // The render answers with the second work alone, which leaves the first
+      // one no row to point at.
+      bibliography: (ids) => ids.slice(1),
+    });
+
+    const { formatted } = await service.load(NOTE);
+
+    expect(firstSerials(formatted.get(CLUSTER))).toEqual([undefined, 1]);
+    await dispose();
+  });
+
+  it("leaves every slot empty when no bibliography can be rendered", async () => {
+    const { service, dispose } = await makeHarness({
+      body: `Both ${CLUSTER}.`,
+      cited: TWO_WORKS,
+      formatCitations: (sources) => Promise.resolve(sources.map(noted)),
+      bibliography: () => null,
+    });
+
+    const { formatted, entrySerials } = await service.load(NOTE);
+
+    expect(entrySerials).toBe(true);
+    expect(firstSerials(formatted.get(CLUSTER))).toEqual([
+      undefined,
+      undefined,
+    ]);
+    await dispose();
+  });
+
+  // An in-text style writes no note, so nothing stands in for one and the
+  // document pays for no bibliography of its own.
+  it("keeps an in-text style's document off serials", async () => {
+    const { service, bibliographyRequests, dispose } = await makeHarness({
+      body: `Both ${CLUSTER}.`,
+      cited: TWO_WORKS,
+    });
+
+    const { formatted, entrySerials } = await service.load(NOTE);
+
+    expect(entrySerials).toBe(false);
+    expect(firstSerials(formatted.get(CLUSTER))).toEqual([]);
+    expect(bibliographyRequests).toEqual([]);
     await dispose();
   });
 });

--- a/apps/obsidian/src/services/citation-text/service.test.ts
+++ b/apps/obsidian/src/services/citation-text/service.test.ts
@@ -17,9 +17,10 @@ import {
   ALPHA,
   ALPHA_KEY,
   citation,
+  firstText,
   literalOccurrences,
+  occurrenceTexts,
   rendered,
-  renderedText,
 } from "./__fixtures__";
 import { citationKey, literalSummaryOf } from "./present";
 import { CitationText } from "./service";
@@ -201,7 +202,7 @@ describe("CitationText", () => {
     expect(citationRequests).toEqual([
       { citations: [`@${ALPHA_KEY}`, `[see @${ALPHA_KEY}, p. 3]`] },
     ]);
-    expect(renderedText(formatted.get("[see @alpha, p. 3]"))).toBe(
+    expect(firstText(formatted.get("[see @alpha, p. 3]"))).toBe(
       `«[see @${ALPHA_KEY}, p. 3]»`,
     );
     await dispose();
@@ -268,7 +269,34 @@ describe("CitationText", () => {
       { citations: [`[@${ALPHA_KEY}]`, `[@${ALPHA_KEY}]`] },
     ]);
     expect(formatted.has("[@alpha; @ghost]")).toBe(false);
-    expect(renderedText(formatted.get("[@alpha]"))).toBe(`«[@${ALPHA_KEY}]»`);
+    expect(firstText(formatted.get("[@alpha]"))).toBe(`«[@${ALPHA_KEY}]»`);
+    await dispose();
+  });
+
+  it("holds every occurrence of one source at the place the document writes it", async () => {
+    const body = "First [@alpha]. Then [@alpha].";
+    const { service, dispose } = await makeHarness({
+      body,
+      // Stands in for a position-dependent style, which renders the second
+      // occurrence of a source as the subsequent form.
+      formatCitations: (sources) =>
+        Promise.resolve(
+          sources.map((source, index) =>
+            rendered(index === 0 ? `«${source}»` : "ibid."),
+          ),
+        ),
+    });
+
+    const { formatted } = await service.load(NOTE);
+
+    expect(formatted.get("[@alpha]")?.map(({ start }) => start)).toEqual([
+      body.indexOf("[@alpha]"),
+      body.lastIndexOf("[@alpha]"),
+    ]);
+    expect(occurrenceTexts(formatted.get("[@alpha]"))).toEqual([
+      `«[@${ALPHA_KEY}]»`,
+      "ibid.",
+    ]);
     await dispose();
   });
 
@@ -321,7 +349,7 @@ describe("CitationText over wikilink Citations", () => {
 
     expect(citationRequests).toEqual([{ citations: [`[@${LIT_KEY}, p. 4]`] }]);
     expect(
-      renderedText(
+      firstText(
         formatted.get(
           citationKey({ source: "[@alpha, p. 4]", works: [LIT_KEY] }),
         ),
@@ -501,12 +529,10 @@ describe("CitationText staleness", () => {
     await vi.waitFor(() => expect(citationRequests).toHaveLength(2));
     finishFirst?.([rendered("stale")]);
 
-    expect(renderedText((await superseded).formatted.get("[@alpha]"))).toBe(
+    expect(firstText((await superseded).formatted.get("[@alpha]"))).toBe(
       "fresh",
     );
-    expect(renderedText((await current).formatted.get("[@alpha]"))).toBe(
-      "fresh",
-    );
+    expect(firstText((await current).formatted.get("[@alpha]"))).toBe("fresh");
     await dispose();
   });
 

--- a/apps/obsidian/src/services/citation-text/service.ts
+++ b/apps/obsidian/src/services/citation-text/service.ts
@@ -33,6 +33,7 @@ import type {
 import type { DatabaseService } from "@/services/database/service";
 import { resolveLiteratureNote } from "@/services/note-index/service";
 import type { NoteIndex } from "@/services/note-index/service";
+import type { RenderedCitation } from "@/services/pandoc/engine";
 import type { BibliographyRenderCache } from "@/services/pandoc/render-cache";
 import { Service } from "@/services/service-base";
 
@@ -81,7 +82,10 @@ export interface CitationTextDeps {
   /** What a citekey resolves to, which decides what a Citation can say. */
   noteIndex: Pick<NoteIndex, "on" | "whenIndexed">;
   /** The plugin-wide render cache, which owns the Citation and References Style and the engine. */
-  bibliographyRender: Pick<BibliographyRenderCache, "renderCitations" | "on">;
+  bibliographyRender: Pick<
+    BibliographyRenderCache,
+    "renderCitationsAst" | "on"
+  >;
 }
 
 /**
@@ -274,18 +278,18 @@ export class CitationText extends Service<void> {
     const sources = citations.map(({ renderSource }) => renderSource);
     const items = [...works.values()].map(({ csl }) => csl);
 
-    const rendered = await this.#bibliographyRender.renderCitations(
+    const rendered = await this.#bibliographyRender.renderCitationsAst(
       sources,
       items,
     );
-    const formatted = new Map<string, DocumentFragment>();
+    const formatted = new Map<string, RenderedCitation>();
     // Citations of one identity render alike, so the first answer stands for
     // them all.
     if (rendered?.length === citations.length) {
-      rendered.forEach((fragment, index) => {
+      rendered.forEach((text, index) => {
         const citation = citations[index]!;
         if (citation.complete && !formatted.has(citation.identity)) {
-          formatted.set(citation.identity, fragment);
+          formatted.set(citation.identity, text);
         }
       });
     }

--- a/apps/obsidian/src/services/citation-text/service.ts
+++ b/apps/obsidian/src/services/citation-text/service.ts
@@ -92,14 +92,18 @@ export interface CitationTextDeps {
 }
 
 /**
- * Formats every Citation one document writes in either citing syntax, and hands
- * the same answer to every surface that shows that document — the reading
- * view's post-processors and the editor's widgets alike, so all of them read
- * the same text.
+ * Formats every Citation Occurrence one document writes in either citing
+ * syntax, and hands the same answer to every surface that shows that document —
+ * the reading view's post-processors and the editor's widgets alike.
+ *
+ * Text is keyed by occurrence: under a position-dependent Citation and
+ * References Style two occurrences of one source read differently, each showing
+ * the text the engine produced for it. A surface holding no coordinate for the
+ * occurrence it shows reads the source's first-occurrence text.
  *
  * A wikilink Citation is formatted from the Pandoc source the exporter would
  * write it as, which is the very source the equivalent Citation Cluster
- * carries; the two syntaxes therefore share one render and read alike.
+ * carries; the two syntaxes therefore share one render.
  *
  * Text comes from the plugin-wide bibliography render cache, which is also the
  * References Sidebar's source, so all three surfaces agree on the References
@@ -301,7 +305,7 @@ export class CitationText extends Service<void> {
         else occurrences.push({ start, text });
       });
     }
-    logger.debug("Document citations read", {
+    logger.debug("Document citations read", () => ({
       path: file.path,
       citations: sources.length,
       wikilinks: wikilinks.citations.length,
@@ -310,7 +314,7 @@ export class CitationText extends Service<void> {
         (count, occurrences) => count + occurrences.length,
         0,
       ),
-    });
+    }));
     return {
       formatted,
       summaries: new Map(

--- a/apps/obsidian/src/services/citation-text/service.ts
+++ b/apps/obsidian/src/services/citation-text/service.ts
@@ -14,6 +14,8 @@ import { createNanoEvents } from "@zotlit/shared/nanoevents";
 
 import { BoundedCache } from "@/lib/bounded-cache";
 import { isRenderableCitation } from "@/lib/citation-fragment";
+import type { CitationKey } from "@/lib/citation-fragment";
+import type { TextSpan } from "@/lib/citation-grammar";
 import { registerEvent } from "@/lib/disposables";
 import { itemSummary } from "@/lib/item-summary";
 import { getLogger } from "@/lib/log";
@@ -34,6 +36,7 @@ import type { NoteIndex } from "@/services/note-index/service";
 import type { BibliographyRenderCache } from "@/services/pandoc/render-cache";
 import { Service } from "@/services/service-base";
 
+import { citationKey } from "./present";
 import type { CitationSource, DocumentCitations } from "./present";
 
 export { type DocumentCitations } from "./present";
@@ -51,6 +54,7 @@ const HELD_DOCUMENTS = 8;
 const NO_CITATIONS: DocumentCitations = {
   formatted: new Map(),
   summaries: new Map(),
+  literalWorks: new Map(),
 };
 
 /** One document's citations, and what the read that produced them answered. */
@@ -254,35 +258,34 @@ export class CitationText extends Service<void> {
     const body = await this.#app.vault.cachedRead(file);
     const set = await this.#citationIndex.getDocumentCitationSet(file);
     const wikilinks = this.#wikilinkCitations(file, body, set.occurrences);
-    const cited = set.citations;
-    const { items, summaries } = this.#readCited(
-      citekeysByItem(cited, wikilinks.works),
-    );
+    const literal = worksByCitekey(set.citations);
+    const works = this.#readCited([...literal.values(), ...wikilinks.cited]);
 
     // Both syntaxes go to one render in document order, so a numbering style
     // counts every citation of the document once and in the order it reads.
-    const citations = [
-      ...literalCitations(body, set.occurrences),
+    const placed = [
+      ...literalCitations(body, set.occurrences, literal),
       ...wikilinks.citations,
-    ]
-      .sort((a, b) => a.start - b.start)
-      .flatMap((citation) => {
-        const context = renderContextCitation(citation, summaries);
-        return context === null ? [] : [context];
-      });
+    ].sort((a, b) => a.start - b.start);
+    const citations = placed.flatMap((citation) => {
+      const context = renderContextCitation(citation, works);
+      return context === null ? [] : [context];
+    });
     const sources = citations.map(({ renderSource }) => renderSource);
+    const items = [...works.values()].map(({ csl }) => csl);
 
     const rendered = await this.#bibliographyRender.renderCitations(
       sources,
       items,
     );
     const formatted = new Map<string, DocumentFragment>();
-    // Identical sources render alike, so the first answer stands for them all.
+    // Citations of one identity render alike, so the first answer stands for
+    // them all.
     if (rendered?.length === citations.length) {
       rendered.forEach((fragment, index) => {
         const citation = citations[index]!;
-        if (citation.complete && !formatted.has(citation.source)) {
-          formatted.set(citation.source, fragment);
+        if (citation.complete && !formatted.has(citation.identity)) {
+          formatted.set(citation.identity, fragment);
         }
       });
     }
@@ -293,7 +296,13 @@ export class CitationText extends Service<void> {
       items: items.length,
       formatted: formatted.size,
     });
-    return { formatted, summaries };
+    return {
+      formatted,
+      summaries: new Map(
+        [...works].map(([indexedKey, { summary }]) => [indexedKey, summary]),
+      ),
+      literalWorks: literal,
+    };
   }
 
   /**
@@ -339,11 +348,11 @@ export class CitationText extends Service<void> {
         body.slice(previous.position.end.offset, next.position.start.offset),
     );
 
-    const works = new Map<string, string>();
+    const cited: string[] = [];
     const citations: PlacedCitation[] = [];
     for (const run of runs) {
       for (const { citation } of run) {
-        works.set(citation.item.citekey, citation.indexedKey);
+        cited.push(citation.indexedKey);
       }
       const citation = citationOfRun(run);
       // A derivation the engine would read back as something else stays out of
@@ -358,35 +367,38 @@ export class CitationText extends Service<void> {
       citations.push({
         start: run[0]!.source.position.start.offset,
         ...citation,
+        identity: citationKey(citation),
       });
     }
-    return { citations, works };
+    return { citations, cited };
   }
 
   /**
    * The cited works, read straight from the database so the surfaces keep
    * working while Zotero is closed.
    *
-   * Citeproc matches a citation by the CSL `id`, so each work is handed over
-   * under the citekey the document names it by — the key the author wrote, or
-   * the native Zotero citation key a wikilink resolves to.
+   * Citeproc matches a citation by the CSL `id`, and the identity a citation
+   * names is its Item, so each work is handed over under its Indexed Key and
+   * every render source names it by that key. Two Literature Notes for one
+   * keyless Item, or a literal citekey beside a wikilink reaching the same
+   * Item, therefore reach one entry — which is what lets a numbering style
+   * count one physical source once.
    *
-   * @param cited the citekeys naming each Indexed Key the document cites.
+   * @see HeldCitation — why a citekey spelling identifies no Item.
+   *
+   * @param cited the Indexed Key of each work the document cites, in the order
+   *   the document cites them; repeats are read once.
+   * @returns the readable works by Indexed Key, in first-cited order.
    */
-  #readCited(cited: ReadonlyMap<string, ReadonlySet<string>>): {
-    items: CslItemData[];
-    summaries: Map<string, string>;
-  } {
-    const items: CslItemData[] = [];
-    const summaries = new Map<string, string>();
-    if (this.#db.state !== "ready" || cited.size === 0) {
-      return { items, summaries };
-    }
+  #readCited(cited: readonly string[]): Map<string, CitedItem> {
+    const works = new Map<string, CitedItem>();
+    if (this.#db.state !== "ready" || cited.length === 0) return works;
 
     try {
       const client = this.#db.client;
       const user = getZoteroIdentity(client);
-      for (const [indexedKey, citekeys] of cited) {
+      for (const indexedKey of cited) {
+        if (works.has(indexedKey)) continue;
         const selector = resolveIndexedKeyLibrary(client, indexedKey);
         if (!selector) continue;
         const item = getItemsByKey(client, selector.libraryID, [
@@ -397,37 +409,39 @@ export class CitationText extends Service<void> {
         if (isChildItemFields(fields)) continue;
 
         const { title, subtitle } = itemSummary(item, fields);
-        const csl = itemToCsl(item, user);
-        for (const citekey of citekeys) {
-          // One citekey names one work here: a document that reaches two
-          // through it — a literal key and a wikilink whose Item carries the
-          // same native citation key — keeps the first work read.
-          if (summaries.has(citekey)) {
-            logger.debug("Citekey names two works in one document", {
-              citekey,
-              dropped: indexedKey,
-            });
-            continue;
-          }
-          summaries.set(citekey, subtitle || title);
-          items.push({ ...csl, id: citekey });
-        }
+        works.set(indexedKey, {
+          csl: { ...itemToCsl(item, user), id: indexedKey },
+          summary: subtitle || title,
+        });
       }
     } catch (error) {
       logger.warn("Cannot read the cited items", { error });
     }
-    return { items, summaries };
+    return works;
   }
+}
+
+/** One cited work, as the render and the display surfaces read it. */
+interface CitedItem {
+  /** The work as the engine reads it, its `id` the Indexed Key a source names it by. */
+  csl: CslItemData;
+  /** `Creators (Year)`, the navigation label of every citekey naming this work. */
+  summary: string;
 }
 
 /** One Citation of a document, at the offset the document writes it. */
 interface PlacedCitation extends CitationSource {
   start: number;
+  /** The Indexed Key each of `keys` names, or `null` for one naming no Item. */
+  works: (string | null)[];
+  /** {@link citationKey} of the Citation, as the surface showing it holds it. */
+  identity: string;
 }
 
 /** One engine input and whether its output may replace the native source. */
 interface RenderContextCitation {
-  source: string;
+  /** {@link PlacedCitation.identity} */
+  identity: string;
   renderSource: string;
   complete: boolean;
 }
@@ -436,14 +450,40 @@ interface RenderContextCitation {
 interface DocumentWikilinks {
   /** The Citations they write, one per Citation Run, in document order. */
   citations: PlacedCitation[];
-  /** The Indexed Key each derived citekey names. */
-  works: Map<string, string>;
+  /**
+   * The Indexed Key of every Item they cite, in document order — the two Items
+   * of a shared spelling included, and a Citation no Pandoc source can name
+   * included too, because its work still carries the summary a surface shows.
+   */
+  cited: string[];
 }
 
-/** The literal Citation Clusters of a document body, in document order. */
+/**
+ * @param cited the document's Citations, over both syntaxes.
+ * @returns the Item each literal citekey names. One spelling names one Item —
+ *   the citekey resolution snapshot decides which — so one entry answers for
+ *   every occurrence of it.
+ */
+function worksByCitekey(cited: readonly Citation[]): Map<string, string> {
+  const works = new Map<string, string>();
+  for (const { indexedKey, occurrences } of cited) {
+    if (indexedKey === null) continue;
+    for (const { kind, raw } of occurrences) {
+      if (kind === "citekey" && !works.has(raw)) works.set(raw, indexedKey);
+    }
+  }
+  return works;
+}
+
+/**
+ * The literal Citation Clusters of a document body, in document order.
+ *
+ * @param works the Item each literal citekey of the document names.
+ */
 function literalCitations(
   body: string,
   occurrences: readonly CitationOccurrence[],
+  works: ReadonlyMap<string, string>,
 ): PlacedCitation[] {
   const members = new Set(
     occurrences
@@ -452,37 +492,100 @@ function literalCitations(
   );
   return scanDocumentCitations(body)
     .filter(({ keys }) => keys.every((key) => members.has(key.start)))
-    .map(({ start, end, keys }) => ({
-      start,
-      source: body.slice(start, end),
-      keys: keys.map((key) => ({
-        citekey: key.citekey,
-        start: key.start - start,
-        end: key.end - start,
-      })),
-    }));
+    .map(({ start, end, keys }) => {
+      const source = body.slice(start, end);
+      return {
+        start,
+        source,
+        // The works below say what this citation renders from; they stay out
+        // of its identity, because one literal spelling names one Item.
+        identity: citationKey({ source }),
+        keys: keys.map((key) => ({
+          citekey: key.citekey,
+          start: key.start - start,
+          end: key.end - start,
+        })),
+        works: keys.map((key) => works.get(key.citekey) ?? null),
+      };
+    });
 }
 
 /**
- * Keeps every resolved item in CSL's document context. A partial Citation
- * Cluster enters that context with only its resolved members, while its output
- * is discarded so the author still sees the complete native source.
+ * Keeps every resolved item in CSL's document context, naming each by the Item
+ * it cites rather than by the citekey the source spells it with. A partial
+ * Citation Cluster enters that context with only its resolved members, while
+ * its output is discarded so the author still sees the complete native source.
  */
 function renderContextCitation(
-  citation: CitationSource,
-  summaries: ReadonlyMap<string, string>,
+  citation: PlacedCitation,
+  works: ReadonlyMap<string, CitedItem>,
 ): RenderContextCitation | null {
-  const resolved = citation.keys.map(({ citekey }) => summaries.has(citekey));
-  if (resolved.every(Boolean)) {
+  const ids = citation.works.map((indexedKey) =>
+    indexedKey !== null && works.has(indexedKey) ? indexedKey : null,
+  );
+  if (ids.every((id) => id === null)) return null;
+
+  const named = namedByWork(citation.source, citation.keys, ids);
+  if (ids.every((id) => id !== null)) {
     return {
-      source: citation.source,
-      renderSource: citation.source,
+      identity: citation.identity,
+      renderSource: named.source,
       complete: true,
     };
   }
-  if (!resolved.some(Boolean)) return null;
+  const members = resolvedMembers(named.source, named.keys, ids);
+  if (members === null) return null;
+  return {
+    identity: citation.identity,
+    renderSource: members,
+    complete: false,
+  };
+}
 
-  const { source, keys } = citation;
+/**
+ * `source` with every resolved key token rewritten to the Indexed Key of the
+ * work it cites, which is the CSL `id` that work is handed to the engine under.
+ *
+ * A key span covers the complete citation token, the author-suppression `-`
+ * included, so the marker is read off the source and written back. An Indexed
+ * Key is letters and digits alone, so the rewritten token is always a Pandoc
+ * key even where the spelling it replaces was not.
+ *
+ * @returns the rewritten source and the key spans relocated in it.
+ */
+function namedByWork(
+  source: string,
+  keys: readonly CitationKey[],
+  ids: readonly (string | null)[],
+): { source: string; keys: TextSpan[] } {
+  const spans: TextSpan[] = [];
+  let named = "";
+  let read = 0;
+  for (const [index, key] of keys.entries()) {
+    const id = ids[index]!;
+    named += source.slice(read, key.start);
+    const start = named.length;
+    named +=
+      id === null
+        ? source.slice(key.start, key.end)
+        : `${source[key.start] === "-" ? "-" : ""}@${id}`;
+    spans.push({ start, end: named.length });
+    read = key.end;
+  }
+  return { source: named + source.slice(read), keys: spans };
+}
+
+/**
+ * The cluster of `source` with its unresolved members cut out, so the resolved
+ * ones still enter the document's render context.
+ *
+ * @returns null when `source` is no cluster the members can be cut out of.
+ */
+function resolvedMembers(
+  source: string,
+  keys: readonly TextSpan[],
+  ids: readonly (string | null)[],
+): string | null {
   if (!source.startsWith("[") || !source.endsWith("]")) return null;
   const separators: number[] = [];
   for (let index = 0; index < keys.length - 1; index += 1) {
@@ -491,41 +594,12 @@ function renderContextCitation(
     separators.push(separator);
   }
   const members: string[] = [];
-  for (const [index, isResolved] of resolved.entries()) {
-    if (!isResolved) continue;
+  for (const [index, id] of ids.entries()) {
+    if (id === null) continue;
     const from = index === 0 ? 1 : separators[index - 1]! + 1;
     const to =
       index === keys.length - 1 ? source.length - 1 : separators[index]!;
     members.push(source.slice(from, to).trim());
   }
-  return {
-    source,
-    renderSource: `[${members.join("; ")}]`,
-    complete: false,
-  };
-}
-
-/**
- * The citekeys naming each Indexed Key the document cites, over both syntaxes —
- * one work cited as a citekey and as a wikilink reaches the database once and
- * answers under both names.
- */
-function citekeysByItem(
-  cited: readonly Citation[],
-  works: ReadonlyMap<string, string>,
-): Map<string, Set<string>> {
-  const byItem = new Map<string, Set<string>>();
-  const add = (indexedKey: string, citekey: string): void => {
-    const citekeys = byItem.get(indexedKey);
-    if (citekeys) citekeys.add(citekey);
-    else byItem.set(indexedKey, new Set([citekey]));
-  };
-  for (const { indexedKey, occurrences } of cited) {
-    if (indexedKey === null) continue;
-    for (const { kind, raw } of occurrences) {
-      if (kind === "citekey") add(indexedKey, raw);
-    }
-  }
-  for (const [citekey, indexedKey] of works) add(indexedKey, citekey);
-  return byItem;
+  return `[${members.join("; ")}]`;
 }

--- a/apps/obsidian/src/services/citation-text/service.ts
+++ b/apps/obsidian/src/services/citation-text/service.ts
@@ -33,6 +33,7 @@ import type {
 import type { DatabaseService } from "@/services/database/service";
 import { resolveLiteratureNote } from "@/services/note-index/service";
 import type { NoteIndex } from "@/services/note-index/service";
+import { holdsNote } from "@/services/pandoc/inline-content";
 import type { BibliographyRenderCache } from "@/services/pandoc/render-cache";
 import { Service } from "@/services/service-base";
 
@@ -57,9 +58,13 @@ const HELD_DOCUMENTS = 8;
 
 const NO_CITATIONS: DocumentCitations = {
   formatted: new Map(),
+  entrySerials: false,
   summaries: new Map(),
   literalWorks: new Map(),
 };
+
+/** What a citation shows in place of a note where no serial stands for one. */
+const NO_SERIALS: readonly undefined[] = [];
 
 /** One document's citations, and what the read that produced them answered. */
 interface HeldCitations {
@@ -87,7 +92,7 @@ export interface CitationTextDeps {
   /** The plugin-wide render cache, which owns the Citation and References Style and the engine. */
   bibliographyRender: Pick<
     BibliographyRenderCache,
-    "renderCitationsAst" | "on"
+    "renderCitationsAst" | "renderAst" | "on"
   >;
 }
 
@@ -283,12 +288,27 @@ export class CitationText extends Service<void> {
       return context === null ? [] : [context];
     });
     const sources = citations.map(({ renderSource }) => renderSource);
-    const items = [...works.values()].map(({ csl }) => csl);
+    // A citation source names each work by its Indexed Key, which is the one
+    // CSL id a Pandoc citekey can spell; the bibliography addresses the same
+    // work by the item identity its own render carries.
+    const items = [...works].map(([indexedKey, { csl }]) => ({
+      ...csl,
+      id: indexedKey,
+    }));
 
     const rendered = await this.#bibliographyRender.renderCitationsAst(
       sources,
       items,
     );
+    // A style whose citations are footnotes leaves a note in the rendered
+    // content, which no surface can show. That output — not the style — is
+    // what puts the whole document on Entry Serials.
+    const entrySerials =
+      rendered?.some(({ content }) => holdsNote(content)) ?? false;
+    const serials = entrySerials
+      ? await this.#readSerials(set.citations, works)
+      : null;
+
     // Each occurrence keeps the text rendered for its own place in the
     // document, which is what a position-dependent style renders differently
     // from one occurrence of a source to the next. The render answers in the
@@ -299,10 +319,19 @@ export class CitationText extends Service<void> {
       rendered.forEach((text, index) => {
         const { identity, start, complete } = citations[index]!;
         if (!complete) return;
+        // One slot per work the citation names, in the order it names them,
+        // whichever mode it names each of them in.
+        const occurrence: FormattedOccurrence = {
+          start,
+          text,
+          serials:
+            serials === null
+              ? NO_SERIALS
+              : text.citations.map(({ id }) => serials.get(id)),
+        };
         const occurrences = formatted.get(identity);
-        if (occurrences === undefined)
-          formatted.set(identity, [{ start, text }]);
-        else occurrences.push({ start, text });
+        if (occurrences === undefined) formatted.set(identity, [occurrence]);
+        else occurrences.push(occurrence);
       });
     }
     logger.debug("Document citations read", () => ({
@@ -310,6 +339,7 @@ export class CitationText extends Service<void> {
       citations: sources.length,
       wikilinks: wikilinks.citations.length,
       items: items.length,
+      entrySerials,
       formatted: [...formatted.values()].reduce(
         (count, occurrences) => count + occurrences.length,
         0,
@@ -317,11 +347,46 @@ export class CitationText extends Service<void> {
     }));
     return {
       formatted,
+      entrySerials,
       summaries: new Map(
         [...works].map(([indexedKey, { summary }]) => [indexedKey, summary]),
       ),
       literalWorks: literal,
     };
+  }
+
+  /**
+   * The Entry Serial of each cited work, by the Indexed Key its citations name
+   * it under.
+   *
+   * A serial is a work's place in the References Sidebar's list, so it is read
+   * off the very bibliography that sidebar shows: the same works in the same
+   * order, which the render cache answers for both surfaces from one render.
+   *
+   * @returns the serials by Indexed Key; a work the bibliography rendered no
+   *   entry for is absent, and every work is absent when no bibliography could
+   *   be rendered at all, which shows the citation a ⚠ in each slot.
+   */
+  async #readSerials(
+    citations: readonly Citation[],
+    works: ReadonlyMap<string, CitedItem>,
+  ): Promise<ReadonlyMap<string, number>> {
+    const serials = new Map<string, number>();
+    const outcome = await this.#bibliographyRender.renderAst(
+      bibliographyItems(citations, works),
+    );
+    if (outcome.kind !== "rendered") {
+      logger.debug("Cannot number the cited entries", { kind: outcome.kind });
+      return serials;
+    }
+    const places = new Map(
+      outcome.entries.map(({ id }, index) => [id, index + 1]),
+    );
+    for (const [indexedKey, { csl }] of works) {
+      const serial = places.get(csl.id);
+      if (serial !== undefined) serials.set(indexedKey, serial);
+    }
+    return serials;
   }
 
   /**
@@ -429,7 +494,7 @@ export class CitationText extends Service<void> {
 
         const { title, subtitle } = itemSummary(item, fields);
         works.set(indexedKey, {
-          csl: { ...itemToCsl(item, user), id: indexedKey },
+          csl: itemToCsl(item, user),
           summary: subtitle || title,
         });
       }
@@ -442,10 +507,32 @@ export class CitationText extends Service<void> {
 
 /** One cited work, as the render and the display surfaces read it. */
 interface CitedItem {
-  /** The work as the engine reads it, its `id` the Indexed Key a source names it by. */
+  /** The work as the engine reads it, its `id` the item identity a bibliography entry carries. */
   csl: CslItemData;
   /** `Creators (Year)`, the navigation label of every citekey naming this work. */
   summary: string;
+}
+
+/**
+ * The cited works in the order the References Sidebar lists them, which is the
+ * order the document's Citations first name them.
+ *
+ * The sidebar reads its own bibliography from the same works in this same
+ * order, so both surfaces are answered from one render and the serials inline
+ * are the digits that sidebar's gutter shows.
+ *
+ * @param citations one entry per work the document cites, in document order.
+ */
+function bibliographyItems(
+  citations: readonly Citation[],
+  works: ReadonlyMap<string, CitedItem>,
+): CslItemData[] {
+  const items: CslItemData[] = [];
+  for (const { indexedKey } of citations) {
+    const work = indexedKey === null ? undefined : works.get(indexedKey);
+    if (work) items.push(work.csl);
+  }
+  return items;
 }
 
 /** One Citation of a document, at the offset the document writes it. */

--- a/apps/obsidian/src/services/citation-text/service.ts
+++ b/apps/obsidian/src/services/citation-text/service.ts
@@ -92,7 +92,7 @@ export interface CitationTextDeps {
   /** The plugin-wide render cache, which owns the Citation and References Style and the engine. */
   bibliographyRender: Pick<
     BibliographyRenderCache,
-    "renderCitationsAst" | "renderAst" | "on"
+    "renderCitations" | "render" | "on"
   >;
 }
 
@@ -296,7 +296,7 @@ export class CitationText extends Service<void> {
       id: indexedKey,
     }));
 
-    const rendered = await this.#bibliographyRender.renderCitationsAst(
+    const rendered = await this.#bibliographyRender.renderCitations(
       sources,
       items,
     );
@@ -372,7 +372,7 @@ export class CitationText extends Service<void> {
     works: ReadonlyMap<string, CitedItem>,
   ): Promise<ReadonlyMap<string, number>> {
     const serials = new Map<string, number>();
-    const outcome = await this.#bibliographyRender.renderAst(
+    const outcome = await this.#bibliographyRender.render(
       bibliographyItems(citations, works),
     );
     if (outcome.kind !== "rendered") {

--- a/apps/obsidian/src/services/citation-text/service.ts
+++ b/apps/obsidian/src/services/citation-text/service.ts
@@ -33,12 +33,15 @@ import type {
 import type { DatabaseService } from "@/services/database/service";
 import { resolveLiteratureNote } from "@/services/note-index/service";
 import type { NoteIndex } from "@/services/note-index/service";
-import type { RenderedCitation } from "@/services/pandoc/engine";
 import type { BibliographyRenderCache } from "@/services/pandoc/render-cache";
 import { Service } from "@/services/service-base";
 
 import { citationKey } from "./present";
-import type { CitationSource, DocumentCitations } from "./present";
+import type {
+  CitationSource,
+  DocumentCitations,
+  FormattedOccurrence,
+} from "./present";
 
 export { type DocumentCitations } from "./present";
 
@@ -282,15 +285,20 @@ export class CitationText extends Service<void> {
       sources,
       items,
     );
-    const formatted = new Map<string, RenderedCitation>();
-    // Citations of one identity render alike, so the first answer stands for
-    // them all.
+    // Each occurrence keeps the text rendered for its own place in the
+    // document, which is what a position-dependent style renders differently
+    // from one occurrence of a source to the next. The render answers in the
+    // document order the sources went out in, so every identity's occurrences
+    // are collected in that order too.
+    const formatted = new Map<string, FormattedOccurrence[]>();
     if (rendered?.length === citations.length) {
       rendered.forEach((text, index) => {
-        const citation = citations[index]!;
-        if (citation.complete && !formatted.has(citation.identity)) {
-          formatted.set(citation.identity, text);
-        }
+        const { identity, start, complete } = citations[index]!;
+        if (!complete) return;
+        const occurrences = formatted.get(identity);
+        if (occurrences === undefined)
+          formatted.set(identity, [{ start, text }]);
+        else occurrences.push({ start, text });
       });
     }
     logger.debug("Document citations read", {
@@ -298,7 +306,10 @@ export class CitationText extends Service<void> {
       citations: sources.length,
       wikilinks: wikilinks.citations.length,
       items: items.length,
-      formatted: formatted.size,
+      formatted: [...formatted.values()].reduce(
+        (count, occurrences) => count + occurrences.length,
+        0,
+      ),
     });
     return {
       formatted,
@@ -446,6 +457,8 @@ interface PlacedCitation extends CitationSource {
 interface RenderContextCitation {
   /** {@link PlacedCitation.identity} */
   identity: string;
+  /** {@link PlacedCitation.start} */
+  start: number;
   renderSource: string;
   complete: boolean;
 }
@@ -533,6 +546,7 @@ function renderContextCitation(
   if (ids.every((id) => id !== null)) {
     return {
       identity: citation.identity,
+      start: citation.start,
       renderSource: named.source,
       complete: true,
     };
@@ -541,6 +555,7 @@ function renderContextCitation(
   if (members === null) return null;
   return {
     identity: citation.identity,
+    start: citation.start,
     renderSource: members,
     complete: false,
   };

--- a/apps/obsidian/src/services/citekey-editor/extension.test.ts
+++ b/apps/obsidian/src/services/citekey-editor/extension.test.ts
@@ -26,7 +26,7 @@ vi.mock("obsidian", async (importOriginal) => {
 
 import { editorInfoField } from "obsidian";
 
-import { occurrence, rendered } from "@/services/citation-text/__fixtures__";
+import { occurrences, rendered } from "@/services/citation-text/__fixtures__";
 import type { FormattedOccurrence } from "@/services/citation-text/present";
 
 import {
@@ -120,7 +120,7 @@ describe("citekeyEditorExtension theme hooks", () => {
             navigationEnabled: () => navigationEnabled,
             showFormatted: () => true,
             citationText: () => ({
-              formatted: new Map([["[@doe2024]", occurrence(formatted)]]),
+              formatted: new Map([["[@doe2024]", occurrences(formatted)]]),
               summaries: new Map([[DOE_KEY, "Doe (2024)"]]),
               literalWorks: new Map([["doe2024", DOE_KEY]]),
             }),
@@ -153,7 +153,7 @@ describe("citekeyEditorExtension citation widgets", () => {
   function viewOf(
     doc: string,
     formatted: Map<string, FormattedOccurrence[]> = new Map([
-      ["[@doe2024]", occurrence(rendered("Doe (2024)"))],
+      ["[@doe2024]", occurrences(rendered("Doe (2024)"))],
     ]),
   ) {
     livePreview.mockReturnValue(true);

--- a/apps/obsidian/src/services/citekey-editor/extension.test.ts
+++ b/apps/obsidian/src/services/citekey-editor/extension.test.ts
@@ -153,7 +153,7 @@ describe("citekeyEditorExtension citation widgets", () => {
       summaries: new Map([[DOE_KEY, "Doe (2024)"]]),
       literalWorks: new Map([["doe2024", DOE_KEY]]),
     };
-    const view = new EditorView({
+    return editorView({
       parent: document.body,
       state: EditorState.create({
         doc,
@@ -171,7 +171,6 @@ describe("citekeyEditorExtension citation widgets", () => {
         ],
       }),
     });
-    return Object.assign(view, { [Symbol.dispose]: () => view.destroy() });
   }
 
   it("shows the formatted citation the shared renderer draws", () => {

--- a/apps/obsidian/src/services/citekey-editor/extension.test.ts
+++ b/apps/obsidian/src/services/citekey-editor/extension.test.ts
@@ -121,6 +121,7 @@ describe("citekeyEditorExtension theme hooks", () => {
             showFormatted: () => true,
             citationText: () => ({
               formatted: new Map([["[@doe2024]", occurrences(formatted)]]),
+              entrySerials: false,
               summaries: new Map([[DOE_KEY, "Doe (2024)"]]),
               literalWorks: new Map([["doe2024", DOE_KEY]]),
             }),
@@ -159,6 +160,7 @@ describe("citekeyEditorExtension citation widgets", () => {
     livePreview.mockReturnValue(true);
     const held = {
       formatted,
+      entrySerials: false,
       summaries: new Map([[DOE_KEY, "Doe (2024)"]]),
       literalWorks: new Map([["doe2024", DOE_KEY]]),
     };
@@ -199,8 +201,8 @@ describe("citekeyEditorExtension citation widgets", () => {
         [
           "[@doe2024]",
           [
-            { start: 4, text: rendered("Doe (2024)") },
-            { start: 19, text: rendered("ibid") },
+            { start: 4, text: rendered("Doe (2024)"), serials: [] },
+            { start: 19, text: rendered("ibid"), serials: [] },
           ],
         ],
       ]),

--- a/apps/obsidian/src/services/citekey-editor/extension.test.ts
+++ b/apps/obsidian/src/services/citekey-editor/extension.test.ts
@@ -32,6 +32,9 @@ import {
   citekeyEditorExtension,
 } from "./extension";
 
+/** The Indexed Key `@doe2024` reaches, which is what a summary is held under. */
+const DOE_KEY = "DOE22345";
+
 const stateOf = (doc: string): EditorState => EditorState.create({ doc });
 
 function editorView(options: ConstructorParameters<typeof EditorView>[0]) {
@@ -116,7 +119,8 @@ describe("citekeyEditorExtension theme hooks", () => {
             showFormatted: () => true,
             citationText: () => ({
               formatted: new Map([["[@doe2024]", formatted]]),
-              summaries: new Map([["doe2024", "Doe (2024)"]]),
+              summaries: new Map([[DOE_KEY, "Doe (2024)"]]),
+              literalWorks: new Map([["doe2024", DOE_KEY]]),
             }),
             requestCitationText: () => undefined,
           }),

--- a/apps/obsidian/src/services/citekey-editor/extension.test.ts
+++ b/apps/obsidian/src/services/citekey-editor/extension.test.ts
@@ -26,6 +26,8 @@ vi.mock("obsidian", async (importOriginal) => {
 
 import { editorInfoField } from "obsidian";
 
+import { rendered } from "@/services/citation-text/__fixtures__";
+
 import {
   citekeyAtPos,
   citekeyDecorationsChanged,
@@ -103,8 +105,7 @@ describe("citekeyEditorExtension theme hooks", () => {
     livePreview.mockReturnValue(true);
     let navigationEnabled = true;
     const opened: string[] = [];
-    const formatted = document.createDocumentFragment();
-    formatted.append("Doe (2024)");
+    const formatted = rendered("Doe (2024)");
     using view = editorView({
       parent: document.body,
       state: EditorState.create({
@@ -140,5 +141,58 @@ describe("citekeyEditorExtension theme hooks", () => {
       ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     expect(opened).toEqual(["doe2024"]);
+  });
+});
+
+describe("citekeyEditorExtension citation widgets", () => {
+  /** One view over `doc`, with one citation held as the formatted text below. */
+  function viewOf(doc: string) {
+    livePreview.mockReturnValue(true);
+    const held = {
+      formatted: new Map([["[@doe2024]", rendered("Doe (2024)")]]),
+      summaries: new Map([[DOE_KEY, "Doe (2024)"]]),
+      literalWorks: new Map([["doe2024", DOE_KEY]]),
+    };
+    const view = new EditorView({
+      parent: document.body,
+      state: EditorState.create({
+        doc,
+        extensions: [
+          editorInfoField,
+          citekeyEditorExtension({
+            open: () => undefined,
+            hoverNotePath: () => null,
+            resolves: () => true,
+            navigationEnabled: () => false,
+            showFormatted: () => true,
+            citationText: () => held,
+            requestCitationText: () => undefined,
+          }),
+        ],
+      }),
+    });
+    return Object.assign(view, { [Symbol.dispose]: () => view.destroy() });
+  }
+
+  it("shows the formatted citation the shared renderer draws", () => {
+    using view = viewOf("[@doe2024]");
+
+    expect(view.dom.querySelector(".zt-citation")?.textContent).toBe(
+      "Doe (2024)",
+    );
+  });
+
+  it("keeps the drawn citation while an edit lands away from it", () => {
+    using view = viewOf("[@doe2024] tail");
+    const drawn = view.dom.querySelector(".zt-citation");
+    expect(drawn?.textContent).toBe("Doe (2024)");
+
+    view.dispatch({
+      changes: { from: view.state.doc.length, insert: " more" },
+    });
+
+    // The held text is one shared value, so the widget compares equal by
+    // reference and CodeMirror keeps the element it already drew.
+    expect(view.dom.querySelector(".zt-citation")).toBe(drawn);
   });
 });

--- a/apps/obsidian/src/services/citekey-editor/extension.test.ts
+++ b/apps/obsidian/src/services/citekey-editor/extension.test.ts
@@ -26,7 +26,8 @@ vi.mock("obsidian", async (importOriginal) => {
 
 import { editorInfoField } from "obsidian";
 
-import { rendered } from "@/services/citation-text/__fixtures__";
+import { occurrence, rendered } from "@/services/citation-text/__fixtures__";
+import type { FormattedOccurrence } from "@/services/citation-text/present";
 
 import {
   citekeyAtPos,
@@ -119,7 +120,7 @@ describe("citekeyEditorExtension theme hooks", () => {
             navigationEnabled: () => navigationEnabled,
             showFormatted: () => true,
             citationText: () => ({
-              formatted: new Map([["[@doe2024]", formatted]]),
+              formatted: new Map([["[@doe2024]", occurrence(formatted)]]),
               summaries: new Map([[DOE_KEY, "Doe (2024)"]]),
               literalWorks: new Map([["doe2024", DOE_KEY]]),
             }),
@@ -145,11 +146,19 @@ describe("citekeyEditorExtension theme hooks", () => {
 });
 
 describe("citekeyEditorExtension citation widgets", () => {
-  /** One view over `doc`, with one citation held as the formatted text below. */
-  function viewOf(doc: string) {
+  /**
+   * One view over `doc`, with `formatted` held as its citation text — by
+   * default one occurrence of `[@doe2024]`.
+   */
+  function viewOf(
+    doc: string,
+    formatted: Map<string, FormattedOccurrence[]> = new Map([
+      ["[@doe2024]", occurrence(rendered("Doe (2024)"))],
+    ]),
+  ) {
     livePreview.mockReturnValue(true);
     const held = {
-      formatted: new Map([["[@doe2024]", rendered("Doe (2024)")]]),
+      formatted,
       summaries: new Map([[DOE_KEY, "Doe (2024)"]]),
       literalWorks: new Map([["doe2024", DOE_KEY]]),
     };
@@ -179,6 +188,29 @@ describe("citekeyEditorExtension citation widgets", () => {
     expect(view.dom.querySelector(".zt-citation")?.textContent).toBe(
       "Doe (2024)",
     );
+  });
+
+  it("shows each occurrence the text held for its own document offset", () => {
+    // A position-dependent style renders the second occurrence of one source
+    // as the subsequent form; each widget matches its own editor offset.
+    using view = viewOf(
+      "One [@doe2024] and [@doe2024].",
+      new Map([
+        [
+          "[@doe2024]",
+          [
+            { start: 4, text: rendered("Doe (2024)") },
+            { start: 19, text: rendered("ibid") },
+          ],
+        ],
+      ]),
+    );
+
+    expect(
+      [...view.dom.querySelectorAll(".zt-citation")].map(
+        (element) => element.textContent,
+      ),
+    ).toEqual(["Doe (2024)", "ibid"]);
   });
 
   it("keeps the drawn citation while an edit lands away from it", () => {

--- a/apps/obsidian/src/services/citekey-editor/extension.ts
+++ b/apps/obsidian/src/services/citekey-editor/extension.ts
@@ -30,7 +30,10 @@ import {
   literalSummaryOf,
   unresolvedKeys,
 } from "@/services/citation-text/present";
-import type { DocumentCitations } from "@/services/citation-text/present";
+import type {
+  DocumentCitations,
+  PresentedCitation,
+} from "@/services/citation-text/present";
 import {
   attachCitationNavigation,
   mouseGesture,
@@ -42,7 +45,6 @@ import type {
   EditorMode,
   NavigationPane,
 } from "@/services/citekey-navigation";
-import type { RenderedCitation } from "@/services/pandoc/engine";
 
 import {
   citationRanges,
@@ -356,7 +358,7 @@ class CitationWidget extends WidgetType {
 
   constructor(options: {
     source: string;
-    content: RenderedCitation;
+    content: PresentedCitation;
     works: readonly CitedWork[];
     sourcePath: string;
     handlers: CitekeyEditorHandlers;

--- a/apps/obsidian/src/services/citekey-editor/extension.ts
+++ b/apps/obsidian/src/services/citekey-editor/extension.ts
@@ -42,6 +42,7 @@ import type {
   EditorMode,
   NavigationPane,
 } from "@/services/citekey-navigation";
+import type { RenderedCitation } from "@/services/pandoc/engine";
 
 import {
   citationRanges,
@@ -340,9 +341,9 @@ interface EditedDocument {
  * One Citation shown as the text a style formatted.
  *
  * Two widgets are the same when they stand for the same source and show the
- * same content: formatted content is the very object the document's held
- * citations carry, so a fresh read of that document is a fresh object and
- * redraws.
+ * same content: formatted content is the immutable value the document's held
+ * citations carry, so the comparison is a reference test and a fresh read of
+ * that document is a fresh value that redraws.
  */
 class CitationWidget extends WidgetType {
   readonly #source;
@@ -355,7 +356,7 @@ class CitationWidget extends WidgetType {
 
   constructor(options: {
     source: string;
-    content: DocumentFragment | string;
+    content: RenderedCitation;
     works: readonly CitedWork[];
     sourcePath: string;
     handlers: CitekeyEditorHandlers;

--- a/apps/obsidian/src/services/citekey-editor/extension.ts
+++ b/apps/obsidian/src/services/citekey-editor/extension.ts
@@ -27,6 +27,8 @@ import {
   citationContent,
   citationElement,
   citedWorks,
+  literalSummaryOf,
+  unresolvedKeys,
 } from "@/services/citation-text/present";
 import type { DocumentCitations } from "@/services/citation-text/present";
 import {
@@ -497,9 +499,8 @@ function citationWidget(
 ): CitationWidget | null {
   const content = citationContent(citation, citations);
   if (content === null) return null;
-  const unresolved = citation.keys.filter(
-    (key) => !citations.summaries.has(key.citekey),
-  ).length;
+  const summaryOf = literalSummaryOf(citations);
+  const unresolved = unresolvedKeys(citation, summaryOf);
   const themeClasses =
     unresolved === 0
       ? []
@@ -511,7 +512,7 @@ function citationWidget(
   return new CitationWidget({
     source: citation.source,
     content,
-    works: citedWorks(citation, (citekey) => citations.summaries.get(citekey)),
+    works: citedWorks(citation, summaryOf),
     sourcePath: path,
     handlers,
     themeClasses,

--- a/apps/obsidian/src/services/citekey-editor/extension.ts
+++ b/apps/obsidian/src/services/citekey-editor/extension.ts
@@ -452,7 +452,12 @@ function buildDecorations(
           const from = line.from + citation.start;
           const to = line.from + citation.end;
           if (overlapsSelection(selection, from, to)) continue;
-          const widget = citationWidget(citation, edited, handlers);
+          const widget = citationWidget({
+            citation,
+            start: from,
+            edited,
+            handlers,
+          });
           if (widget === null) continue;
           replaced.push(citation);
           placed.push({
@@ -493,12 +498,23 @@ function buildDecorations(
  * @returns the widget for one Citation. An unresolved Citation keeps its
  *   source text and error hook, without navigation handlers.
  */
-function citationWidget(
-  citation: CitationRange,
-  { citations, path }: EditedDocument,
-  handlers: CitekeyEditorHandlers,
-): CitationWidget | null {
-  const content = citationContent(citation, citations);
+function citationWidget(options: {
+  citation: CitationRange;
+  /** Document offset the Citation starts at, which picks out its occurrence. */
+  start: number;
+  edited: EditedDocument;
+  handlers: CitekeyEditorHandlers;
+}): CitationWidget | null {
+  const {
+    citation,
+    start,
+    edited: { citations, path },
+    handlers,
+  } = options;
+  const content = citationContent(citation, citations, {
+    kind: "offset",
+    start,
+  });
   if (content === null) return null;
   const summaryOf = literalSummaryOf(citations);
   const unresolved = unresolvedKeys(citation, summaryOf);

--- a/apps/obsidian/src/services/citekey-editor/service.test.ts
+++ b/apps/obsidian/src/services/citekey-editor/service.test.ts
@@ -233,7 +233,11 @@ class CitationTextStub {
   }
 
   load(): Promise<DocumentCitations> {
-    return Promise.resolve({ formatted: new Map(), summaries: new Map() });
+    return Promise.resolve({
+      formatted: new Map(),
+      summaries: new Map(),
+      literalWorks: new Map(),
+    });
   }
 
   on(event: string, cb: (path?: string) => void): () => void {

--- a/apps/obsidian/src/services/citekey-editor/service.test.ts
+++ b/apps/obsidian/src/services/citekey-editor/service.test.ts
@@ -235,6 +235,7 @@ class CitationTextStub {
   load(): Promise<DocumentCitations> {
     return Promise.resolve({
       formatted: new Map(),
+      entrySerials: false,
       summaries: new Map(),
       literalWorks: new Map(),
     });

--- a/apps/obsidian/src/services/citekey-reading/render.ts
+++ b/apps/obsidian/src/services/citekey-reading/render.ts
@@ -49,8 +49,16 @@ export function sectionCitations(root: HTMLElement): SectionCitation[] {
   return found;
 }
 
-/** The node to put in a citation's place, or `null` to leave its source alone. */
-export type FormatCitation = (citation: SectionCitation) => Node | null;
+/**
+ * The node to put in a citation's place, or `null` to leave its source alone.
+ *
+ * `index` is the citation's place in the section's own document order, which is
+ * what tells two identical sources of one section apart.
+ */
+export type FormatCitation = (
+  citation: SectionCitation,
+  index: number,
+) => Node | null;
 
 /**
  * Replaces each citation's source text with what `format` returns for it.
@@ -62,8 +70,9 @@ export function replaceCitations(
   citations: readonly SectionCitation[],
   format: FormatCitation,
 ): void {
-  for (const citation of [...citations].reverse()) {
-    const formatted = format(citation);
+  for (let index = citations.length - 1; index >= 0; index -= 1) {
+    const citation = citations[index]!;
+    const formatted = format(citation, index);
     if (!formatted) continue;
     const { node, start, end } = citation;
     node.splitText(end);

--- a/apps/obsidian/src/services/citekey-reading/service.test.ts
+++ b/apps/obsidian/src/services/citekey-reading/service.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment happy-dom
 import { MarkdownView } from "obsidian";
-import type { MarkdownPostProcessor, TFile } from "obsidian";
+import type {
+  MarkdownPostProcessor,
+  MarkdownPostProcessorContext,
+  TFile,
+} from "obsidian";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getItemsByKey, resolveIndexedKeyLibrary } from "@zotlit/db";
@@ -45,6 +49,15 @@ function section(html: string): HTMLElement {
 
 interface Harness extends AsyncDisposable {
   process: MarkdownPostProcessor;
+  /**
+   * The context Obsidian hands a post-processor for the body lines `lines`
+   * covers, or for a section it places nowhere — an embed, a popover.
+   */
+  sectionCtx: (
+    lines: { from: number; to: number } | null,
+  ) => MarkdownPostProcessorContext;
+  /** {@link sectionCtx} over the whole body, which is one section for most suites. */
+  ctx: MarkdownPostProcessorContext;
   citationRequests: { citations: readonly string[] }[];
 }
 
@@ -53,6 +66,7 @@ async function makeHarness({
   cited = [citation("alpha", ALPHA_KEY)],
   formats = true,
   formatCitations,
+  renderText = (source) => `«${source}»`,
   overrides = {},
 }: {
   body: string;
@@ -63,6 +77,8 @@ async function makeHarness({
   formatCitations?: (
     citations: readonly string[],
   ) => Promise<readonly RenderedCitation[] | null>;
+  /** The text the render answers for each source, by its place in the request. */
+  renderText?: (source: string, index: number) => string;
   overrides?: Partial<Settings>;
 }): Promise<Harness> {
   await using stack = new AsyncDisposableStack();
@@ -98,7 +114,9 @@ async function makeHarness({
             ? formatCitations(citations)
             : Promise.resolve(
                 formats
-                  ? citations.map((source) => rendered(`«${source}»`))
+                  ? citations.map((source, index) =>
+                      rendered(renderText(source, index)),
+                    )
                   : null,
               );
         },
@@ -143,8 +161,19 @@ async function makeHarness({
   await service.ready;
   const resources = stack.move();
 
+  const sectionCtx = (
+    lines: { from: number; to: number } | null,
+  ): MarkdownPostProcessorContext =>
+    ({
+      sourcePath: "note.md",
+      getSectionInfo: () =>
+        lines && { text: body, lineStart: lines.from, lineEnd: lines.to },
+    }) as never;
+
   return {
     process: process!,
+    sectionCtx,
+    ctx: sectionCtx({ from: 0, to: body.split("\n").length - 1 }),
     citationRequests,
     [Symbol.asyncDispose]: () => resources.disposeAsync(),
   };
@@ -196,13 +225,47 @@ describe("CitekeyReading", () => {
     await using harnessed = await makeHarness({
       body: "Blah [see @alpha, p. 3] blah.",
     });
-    const { process } = harnessed;
+    const { process, ctx } = harnessed;
     const el = section("<p>Blah [see @alpha, p. 3] blah.</p>");
 
-    await process(el, { sourcePath: "note.md" } as never);
+    await process(el, ctx);
 
     expect(el.textContent).toBe(`Blah «[see @${ALPHA_KEY}, p. 3]» blah.`);
     expect(el.querySelector("span.zt-citation")).not.toBeNull();
+  });
+
+  // Stands in for a position-dependent style, whose second occurrence of one
+  // source reads as the subsequent form.
+  const IBID = (source: string, index: number): string =>
+    index === 0 ? `«${source}»` : "ibid";
+
+  it("shows each occurrence the text rendered for its own place in the document", async () => {
+    await using harnessed = await makeHarness({
+      body: "One [@alpha].\n\nTwo [@alpha].",
+      renderText: IBID,
+    });
+    const { process, sectionCtx } = harnessed;
+    const first = section("<p>One [@alpha].</p>");
+    const second = section("<p>Two [@alpha].</p>");
+
+    await process(first, sectionCtx({ from: 0, to: 0 }));
+    await process(second, sectionCtx({ from: 2, to: 2 }));
+
+    expect(first.textContent).toBe(`One «[@${ALPHA_KEY}]».`);
+    expect(second.textContent).toBe("Two ibid.");
+  });
+
+  it("shows first-occurrence text in a section Obsidian places nowhere", async () => {
+    await using harnessed = await makeHarness({
+      body: "One [@alpha].\n\nTwo [@alpha].",
+      renderText: IBID,
+    });
+    const { process, sectionCtx } = harnessed;
+    const el = section("<p>Two [@alpha].</p>");
+
+    await process(el, sectionCtx(null));
+
+    expect(el.textContent).toBe(`Two «[@${ALPHA_KEY}]».`);
   });
 
   it("keeps source when no engine formats the citation", async () => {
@@ -210,10 +273,10 @@ describe("CitekeyReading", () => {
       body: "Blah [see @alpha, p. 3] blah.",
       formats: false,
     });
-    const { process } = harnessed;
+    const { process, ctx } = harnessed;
     const el = section("<p>Blah [see @alpha, p. 3] blah.</p>");
 
-    await process(el, { sourcePath: "note.md" } as never);
+    await process(el, ctx);
 
     expect(el.textContent).toBe("Blah [see @alpha, p. 3] blah.");
   });
@@ -223,10 +286,10 @@ describe("CitekeyReading", () => {
       body: "Blah [see @alpha, p. 3] blah.",
       overrides: { "citation.show-formatted": false },
     });
-    const { process } = harnessed;
+    const { process, ctx } = harnessed;
     const el = section("<p>Blah [see @alpha, p. 3] blah.</p>");
 
-    await process(el, { sourcePath: "note.md" } as never);
+    await process(el, ctx);
 
     expect(el.textContent).toBe("Blah [see @alpha, p. 3] blah.");
   });
@@ -240,12 +303,10 @@ describe("CitekeyReading", () => {
       body: "Blah [@alpha].",
       formatCitations: () => pending,
     });
-    const { process } = harnessed;
+    const { process, ctx } = harnessed;
     const el = section("<p>Blah [@alpha].</p>");
 
-    const completion = Promise.resolve(
-      process(el, { sourcePath: "note.md" } as never),
-    );
+    const completion = Promise.resolve(process(el, ctx));
     let completed = false;
     void completion.then(() => {
       completed = true;
@@ -264,10 +325,10 @@ describe("CitekeyReading", () => {
       body: "@ghost blah.",
       cited: [citation("ghost", null)],
     });
-    const { process } = harnessed;
+    const { process, ctx } = harnessed;
     const el = section("<p>@ghost blah.</p>");
 
-    await process(el, { sourcePath: "note.md" } as never);
+    await process(el, ctx);
 
     expect(el.textContent).toBe("@ghost blah.");
   });
@@ -300,10 +361,10 @@ describe("CitekeyReading", () => {
     ];
     for (const { body, cited, classes } of cases) {
       await using harnessed = await makeHarness({ body, cited });
-      const { process } = harnessed;
+      const { process, ctx } = harnessed;
       const el = section(`<p>${body}</p>`);
 
-      await process(el, { sourcePath: "note.md" } as never);
+      await process(el, ctx);
 
       const rendered = el.querySelector("span");
       for (const className of classes) {
@@ -324,10 +385,10 @@ describe("CitekeyReading", () => {
         body: "Blah [@alpha].",
         overrides,
       });
-      const { process } = harnessed;
+      const { process, ctx } = harnessed;
       const el = section("<p>Blah [@alpha].</p>");
 
-      await process(el, { sourcePath: "note.md" } as never);
+      await process(el, ctx);
 
       expect(el.textContent).toBe("Blah [@alpha].");
       expect(el.querySelector(".zt-citation-key")).toBeNull();
@@ -340,11 +401,11 @@ describe("CitekeyReading", () => {
     await using harnessed = await makeHarness({
       body: "Blah [@alpha] blah.",
     });
-    const { process } = harnessed;
+    const { process, ctx } = harnessed;
     const el = section("<p>Blah [@alpha] blah.</p>");
     const block = el.firstElementChild!;
 
-    await process(el, { sourcePath: "note.md" } as never);
+    await process(el, ctx);
 
     expect(el.children).toHaveLength(1);
     expect(el.firstElementChild).toBe(block);
@@ -355,14 +416,10 @@ describe("CitekeyReading", () => {
     await using harnessed = await makeHarness({
       body: "One [@alpha].\n\nTwo [@alpha].",
     });
-    const { process, citationRequests } = harnessed;
+    const { process, ctx, citationRequests } = harnessed;
 
-    await process(section("<p>One [@alpha].</p>"), {
-      sourcePath: "note.md",
-    } as never);
-    await process(section("<p>Two [@alpha].</p>"), {
-      sourcePath: "note.md",
-    } as never);
+    await process(section("<p>One [@alpha].</p>"), ctx);
+    await process(section("<p>Two [@alpha].</p>"), ctx);
 
     expect(citationRequests).toHaveLength(1);
   });

--- a/apps/obsidian/src/services/citekey-reading/service.test.ts
+++ b/apps/obsidian/src/services/citekey-reading/service.test.ts
@@ -10,10 +10,11 @@ import {
   ALPHA,
   ALPHA_KEY,
   citation,
-  fragment,
   literalOccurrences,
+  rendered,
 } from "@/services/citation-text/__fixtures__";
 import { CitationText } from "@/services/citation-text/service";
+import type { RenderedCitation } from "@/services/pandoc/engine";
 import { defaults } from "@/services/settings/schema";
 import type { Settings } from "@/services/settings/schema";
 
@@ -61,7 +62,7 @@ async function makeHarness({
   /** Custom render answer for pending-generation tests. */
   formatCitations?: (
     citations: readonly string[],
-  ) => Promise<readonly DocumentFragment[] | null>;
+  ) => Promise<readonly RenderedCitation[] | null>;
   overrides?: Partial<Settings>;
 }): Promise<Harness> {
   await using stack = new AsyncDisposableStack();
@@ -91,13 +92,13 @@ async function makeHarness({
         whenIndexed: () => Promise.resolve(),
       },
       bibliographyRender: {
-        renderCitations: (citations: readonly string[]) => {
+        renderCitationsAst: (citations: readonly string[]) => {
           citationRequests.push({ citations });
           return formatCitations
             ? formatCitations(citations)
             : Promise.resolve(
                 formats
-                  ? citations.map((source) => fragment(`«${source}»`))
+                  ? citations.map((source) => rendered(`«${source}»`))
                   : null,
               );
         },
@@ -231,8 +232,8 @@ describe("CitekeyReading", () => {
   });
 
   it("keeps source visible while citation text is pending", async () => {
-    let settle: ((value: readonly DocumentFragment[]) => void) | undefined;
-    const pending = new Promise<readonly DocumentFragment[]>((resolve) => {
+    let settle: ((value: readonly RenderedCitation[]) => void) | undefined;
+    const pending = new Promise<readonly RenderedCitation[]>((resolve) => {
       settle = resolve;
     });
     await using harnessed = await makeHarness({
@@ -254,7 +255,7 @@ describe("CitekeyReading", () => {
     expect(completed).toBe(true);
     expect(el.textContent).toBe("Blah [@alpha].");
 
-    settle?.([fragment("«[@alpha]»")]);
+    settle?.([rendered("«[@alpha]»")]);
     await pending;
   });
 

--- a/apps/obsidian/src/services/citekey-reading/service.test.ts
+++ b/apps/obsidian/src/services/citekey-reading/service.test.ts
@@ -200,7 +200,7 @@ describe("CitekeyReading", () => {
 
     await process(el, { sourcePath: "note.md" } as never);
 
-    expect(el.textContent).toBe("Blah «[see @alpha, p. 3]» blah.");
+    expect(el.textContent).toBe(`Blah «[see @${ALPHA_KEY}, p. 3]» blah.`);
     expect(el.querySelector("span.zt-citation")).not.toBeNull();
   });
 

--- a/apps/obsidian/src/services/citekey-reading/service.test.ts
+++ b/apps/obsidian/src/services/citekey-reading/service.test.ts
@@ -108,7 +108,7 @@ async function makeHarness({
         whenIndexed: () => Promise.resolve(),
       },
       bibliographyRender: {
-        renderCitationsAst: (citations: readonly string[]) => {
+        renderCitations: (citations: readonly string[]) => {
           citationRequests.push({ citations });
           return formatCitations
             ? formatCitations(citations)

--- a/apps/obsidian/src/services/citekey-reading/service.ts
+++ b/apps/obsidian/src/services/citekey-reading/service.ts
@@ -10,6 +10,8 @@ import {
   citationContent,
   citationElement,
   citedWorks,
+  literalSummaryOf,
+  unresolvedKeys,
 } from "@/services/citation-text/present";
 import type { CitationText } from "@/services/citation-text/service";
 import type { CitekeyEditor } from "@/services/citekey-editor/service";
@@ -151,16 +153,13 @@ export class CitekeyReading extends Service<void> {
       void this.#citationText.load(file);
       return;
     }
-    const summaryOf = (citekey: string): string | undefined =>
-      text.summaries.get(citekey);
+    const summaryOf = literalSummaryOf(text);
     const doc = el.ownerDocument;
     replaceCitations(citations, (citation) => {
       const content = this.#showFormatted
         ? citationContent(citation, text)
         : null;
-      const unresolved = citation.keys.filter(
-        (key) => !text.summaries.has(key.citekey),
-      ).length;
+      const unresolved = unresolvedKeys(citation, summaryOf);
       const themeClasses = [
         themeHook.citationKey,
         ...(unresolved === 0

--- a/apps/obsidian/src/services/citekey-reading/service.ts
+++ b/apps/obsidian/src/services/citekey-reading/service.ts
@@ -4,13 +4,14 @@ import { MarkdownView } from "obsidian";
 import type { App, MarkdownPostProcessorContext, Plugin } from "obsidian";
 
 import { getLogger } from "@/lib/log";
-import { rerenderReadingViews } from "@/lib/reading-view";
+import { rerenderReadingViews, sectionRange } from "@/lib/reading-view";
 import { themeHook } from "@/lib/theme-hooks";
 import {
   citationContent,
   citationElement,
   citedWorks,
   literalSummaryOf,
+  sectionCoordinates,
   unresolvedKeys,
 } from "@/services/citation-text/present";
 import type { CitationText } from "@/services/citation-text/service";
@@ -155,9 +156,12 @@ export class CitekeyReading extends Service<void> {
     }
     const summaryOf = literalSummaryOf(text);
     const doc = el.ownerDocument;
-    replaceCitations(citations, (citation) => {
+    // Which occurrence each citation of the section is, so a position-dependent
+    // style shows every one of them the text rendered for its own place.
+    const coordinates = sectionCoordinates(citations, sectionRange(ctx, el));
+    replaceCitations(citations, (citation, index) => {
       const content = this.#showFormatted
-        ? citationContent(citation, text)
+        ? citationContent(citation, text, coordinates[index])
         : null;
       const unresolved = unresolvedKeys(citation, summaryOf);
       const themeClasses = [

--- a/apps/obsidian/src/services/pandoc/ast.ts
+++ b/apps/obsidian/src/services/pandoc/ast.ts
@@ -1,0 +1,158 @@
+// The pandoc JSON AST as pandoc-types encodes it, as types alone — no runtime code.
+
+/**
+ * Pandoc's `-t json` output follows the `ToJSON` instances of pandoc-types, and
+ * the plugin pins the binary that writes them (pandoc 3.10.1, pandoc-types
+ * 1.23.1.2), so the encoding is a fixed contract rather than something to
+ * validate. Every constructor is tagged by `t`, and one that takes arguments
+ * carries them in `c` — a tuple when it takes several.
+ *
+ * @see https://github.com/jgm/pandoc-types/blob/1.23.1.2/src/Text/Pandoc/Definition.hs
+ */
+
+/** A constructor that takes no arguments, written as its tag alone. */
+export interface Tag<T extends string> {
+  readonly t: T;
+}
+
+/** A constructor that takes arguments, written as its tag and its payload. */
+export interface Node<T extends string, C> extends Tag<T> {
+  readonly c: C;
+}
+
+export type Inlines = readonly Inline[];
+export type Blocks = readonly Block[];
+
+/** Identifier, classes, and key-value pairs of an element that carries them. */
+export type Attr = readonly [
+  id: string,
+  classes: readonly string[],
+  keyValues: readonly (readonly [key: string, value: string])[],
+];
+
+export type Target = readonly [url: string, title: string];
+
+/** The name of a raw block's or raw inline's output format, such as `html`. */
+export type Format = string;
+
+export type QuoteType = Tag<"SingleQuote" | "DoubleQuote">;
+export type MathType = Tag<"DisplayMath" | "InlineMath">;
+export type CitationMode = Tag<
+  "AuthorInText" | "SuppressAuthor" | "NormalCitation"
+>;
+export type Alignment = Tag<
+  "AlignLeft" | "AlignRight" | "AlignCenter" | "AlignDefault"
+>;
+export type ListNumberStyle = Tag<
+  | "DefaultStyle"
+  | "Example"
+  | "Decimal"
+  | "LowerRoman"
+  | "UpperRoman"
+  | "LowerAlpha"
+  | "UpperAlpha"
+>;
+export type ListNumberDelim = Tag<
+  "DefaultDelim" | "Period" | "OneParen" | "TwoParens"
+>;
+
+export type ListAttributes = readonly [
+  start: number,
+  style: ListNumberStyle,
+  delimiter: ListNumberDelim,
+];
+
+export interface Citation {
+  /** The CSL id the source cites the work by — a citekey spelling. */
+  readonly citationId: string;
+  readonly citationPrefix: Inlines;
+  readonly citationSuffix: Inlines;
+  readonly citationMode: CitationMode;
+  readonly citationNoteNum: number;
+  readonly citationHash: number;
+}
+
+export type Inline =
+  | Node<"Str", string>
+  | Node<"Emph", Inlines>
+  | Node<"Underline", Inlines>
+  | Node<"Strong", Inlines>
+  | Node<"Strikeout", Inlines>
+  | Node<"Superscript", Inlines>
+  | Node<"Subscript", Inlines>
+  | Node<"SmallCaps", Inlines>
+  | Node<"Quoted", readonly [QuoteType, Inlines]>
+  | Node<"Cite", readonly [readonly Citation[], Inlines]>
+  | Node<"Code", readonly [Attr, string]>
+  | Tag<"Space">
+  | Tag<"SoftBreak">
+  | Tag<"LineBreak">
+  | Node<"Math", readonly [MathType, string]>
+  | Node<"RawInline", readonly [Format, string]>
+  | Node<"Link", readonly [Attr, Inlines, Target]>
+  | Node<"Image", readonly [Attr, Inlines, Target]>
+  | Node<"Note", Blocks>
+  | Node<"Span", readonly [Attr, Inlines]>;
+
+export type ColWidth = Node<"ColWidth", number> | Tag<"ColWidthDefault">;
+export type ColSpec = readonly [alignment: Alignment, width: ColWidth];
+export type Caption = readonly [short: Inlines | null, blocks: Blocks];
+export type Cell = readonly [
+  attr: Attr,
+  alignment: Alignment,
+  rowSpan: number,
+  colSpan: number,
+  blocks: Blocks,
+];
+export type Row = readonly [attr: Attr, cells: readonly Cell[]];
+export type TableHead = readonly [attr: Attr, rows: readonly Row[]];
+export type TableBody = readonly [
+  attr: Attr,
+  rowHeadColumns: number,
+  intermediateHead: readonly Row[],
+  rows: readonly Row[],
+];
+export type TableFoot = readonly [attr: Attr, rows: readonly Row[]];
+
+export type Block =
+  | Node<"Plain", Inlines>
+  | Node<"Para", Inlines>
+  | Node<"LineBlock", readonly Inlines[]>
+  | Node<"CodeBlock", readonly [Attr, string]>
+  | Node<"RawBlock", readonly [Format, string]>
+  | Node<"BlockQuote", Blocks>
+  | Node<"OrderedList", readonly [ListAttributes, readonly Blocks[]]>
+  | Node<"BulletList", readonly Blocks[]>
+  | Node<"DefinitionList", readonly (readonly [Inlines, readonly Blocks[]])[]>
+  | Node<"Header", readonly [level: number, attr: Attr, inlines: Inlines]>
+  | Tag<"HorizontalRule">
+  | Node<
+      "Table",
+      readonly [
+        attr: Attr,
+        caption: Caption,
+        columns: readonly ColSpec[],
+        head: TableHead,
+        bodies: readonly TableBody[],
+        foot: TableFoot,
+      ]
+    >
+  | Node<"Figure", readonly [attr: Attr, caption: Caption, blocks: Blocks]>
+  | Node<"Div", readonly [attr: Attr, blocks: Blocks]>;
+
+export type MetaValue =
+  | Node<"MetaMap", Meta>
+  | Node<"MetaList", readonly MetaValue[]>
+  | Node<"MetaBool", boolean>
+  | Node<"MetaString", string>
+  | Node<"MetaInlines", Inlines>
+  | Node<"MetaBlocks", Blocks>;
+
+export type Meta = Readonly<Record<string, MetaValue>>;
+
+/** One converted document. The array's length varies across API families. */
+export interface Pandoc {
+  readonly "pandoc-api-version": readonly number[];
+  readonly meta: Meta;
+  readonly blocks: Blocks;
+}

--- a/apps/obsidian/src/services/pandoc/engine.test.ts
+++ b/apps/obsidian/src/services/pandoc/engine.test.ts
@@ -8,6 +8,7 @@ import type { CslItemData } from "@zotlit/db";
 
 import { yieldToMain } from "@/lib/yield-to-main";
 
+import type { Inlines } from "./ast";
 import {
   CitationEngineError,
   CitationRequestSupersededError,
@@ -131,11 +132,80 @@ const NESTED_BLOCK_STYLE = `<?xml version="1.0" encoding="utf-8"?>
   </bibliography>
 </style>`;
 
+/**
+ * A note-class style, whose citations citeproc renders as footnotes — the case
+ * no inline surface can show, and the reason the typed AST carries `Note`.
+ */
+const NOTE_STYLE = `<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0">
+  <info>
+    <title>Noted</title>
+    <id>http://example.com/noted</id>
+    <updated>2020-01-01T00:00:00+00:00</updated>
+  </info>
+  <citation>
+    <layout delimiter="; ">
+      <names variable="author"><name/></names>
+      <text variable="title" prefix=", " suffix="."/>
+    </layout>
+  </citation>
+  <bibliography>
+    <layout>
+      <names variable="author"><name/></names>
+      <text variable="title" prefix=". " suffix="."/>
+    </layout>
+  </bibliography>
+</style>`;
+
 const RESOLVE_MAP = JSON.stringify({ citations: { "Zeta 2020": ZETA.id } });
 const DOCUMENT = "Cited here [[Zeta 2020]].\n\n# References\n";
 
 async function openEngine(): Promise<CitationEngine> {
   return createCitationEngine(await readFile(WASM_PATH));
+}
+
+/** What an inline flow reads as, which is the text a surface would show. */
+function plainText(inlines: Inlines): string {
+  return inlines
+    .map((inline) => {
+      switch (inline.t) {
+        case "Str":
+          return inline.c;
+        case "Space":
+        case "SoftBreak":
+        case "LineBreak":
+          return " ";
+        case "Emph":
+        case "Underline":
+        case "Strong":
+        case "Strikeout":
+        case "Superscript":
+        case "Subscript":
+        case "SmallCaps":
+          return plainText(inline.c);
+        case "Quoted":
+        case "Cite":
+        case "Link":
+        case "Image":
+        case "Span":
+          return plainText(inline.c[1]);
+        case "Note":
+          return plainText(
+            inline.c.flatMap((block) =>
+              block.t === "Para" || block.t === "Plain" ? block.c : [],
+            ),
+          );
+        default:
+          return "";
+      }
+    })
+    .join("");
+}
+
+/** What a citation renders inside the `Cite` wrapper citeproc leaves around it. */
+function citeInlines(content: Inlines): Inlines {
+  const cite = content.find((inline) => inline.t === "Cite");
+  return cite?.t === "Cite" ? cite.c[1] : [];
 }
 
 describe("createCitationEngine", { timeout: TIMEOUT }, () => {
@@ -312,6 +382,152 @@ describe("createCitationEngine", { timeout: TIMEOUT }, () => {
     expect(await engine.renderCitations({ citations: [], items: [] })).toEqual(
       [],
     );
+  });
+
+  it("hands the bibliography over as typed inlines, in the style's order", async () => {
+    const entries = await engine.renderBibliographyAst({
+      items: [ZETA, ADAMS],
+    });
+
+    expect(entries.map((entry) => entry.id)).toEqual([ADAMS.id, ZETA.id]);
+    expect(plainText(entries.at(1)?.content ?? [])).toContain("Zeta, Ann");
+  });
+
+  it("keys typed entries by a Zotero URI id", async () => {
+    const entries = await engine.renderBibliographyAst({
+      items: [{ ...ZETA, id: ZOTERO_URI_ID }],
+      styleXml: NUMERIC_STYLE,
+    });
+
+    expect(entries.map((entry) => entry.id)).toEqual([ZOTERO_URI_ID]);
+  });
+
+  it("splits the entry marker off as inlines, without the separator space", async () => {
+    const [first] = await engine.renderBibliographyAst({
+      items: [ZETA],
+      styleXml: NUMERIC_STYLE,
+    });
+
+    expect(first?.marker).toEqual([{ t: "Str", c: "[1]" }]);
+    expect(plainText(first?.content ?? [])).toBe(
+      "Ann Zeta. A study of nothing.",
+    );
+  });
+
+  it("leaves the typed marker unset for a style that renders none", async () => {
+    const [first] = await engine.renderBibliographyAst({ items: [ZETA] });
+
+    expect(first?.marker).toBeUndefined();
+    expect(plainText(first?.content ?? [])).toContain("Zeta, Ann");
+  });
+
+  it("passes the display spans of an entry through untouched", async () => {
+    const [first] = await engine.renderBibliographyAst({
+      items: [ZETA],
+      styleXml: BLOCK_STYLE,
+    });
+
+    expect(
+      first?.content.map((inline) =>
+        inline.t === "Span" ? inline.c[0][1] : inline.t,
+      ),
+    ).toEqual([["csl-block"], ["csl-indent"]]);
+  });
+
+  it("renders no typed entries for an empty item set", async () => {
+    await expect(engine.renderBibliographyAst({ items: [] })).resolves.toEqual(
+      [],
+    );
+  });
+
+  it("formats one typed citation per source, in the order they were asked for", async () => {
+    const rendered = await engine.renderCitationsAst({
+      citations: ["[@zeta20]", "@adams18"],
+      items: [
+        { ...ZETA, id: "zeta20" },
+        { ...ADAMS, id: "adams18" },
+      ],
+    });
+
+    expect(rendered.map((citation) => plainText(citation.content))).toEqual([
+      "(Zeta 2020)",
+      "Adams (2018)",
+    ]);
+    expect(rendered.map((citation) => citation.citations)).toEqual([
+      [{ id: "zeta20", mode: "normal" }],
+      [{ id: "adams18", mode: "author-in-text" }],
+    ]);
+  });
+
+  it("names every work a cluster cites, in the mode it cites it", async () => {
+    const [cluster] = await engine.renderCitationsAst({
+      citations: ["[see @zeta20, p. 3; -@adams18]"],
+      items: [
+        { ...ZETA, id: "zeta20" },
+        { ...ADAMS, id: "adams18" },
+      ],
+    });
+
+    expect(cluster?.citations).toEqual([
+      { id: "zeta20", mode: "normal" },
+      { id: "adams18", mode: "suppress-author" },
+    ]);
+    expect(plainText(cluster?.content ?? [])).toBe("(see Zeta 2020, 3; 2018)");
+  });
+
+  it("numbers typed citations across the whole request under a numbered style", async () => {
+    const rendered = await engine.renderCitationsAst({
+      citations: ["[@zeta20]", "[@adams18]", "[@zeta20]"],
+      items: [
+        { ...ZETA, id: "zeta20" },
+        { ...ADAMS, id: "adams18" },
+      ],
+      styleXml: NUMERIC_STYLE,
+    });
+
+    expect(rendered.map((citation) => plainText(citation.content))).toEqual([
+      "[1]",
+      "[2]",
+      "[1]",
+    ]);
+  });
+
+  it("carries a note-class style's footnote in the citation content", async () => {
+    const [plain, authorInText] = await engine.renderCitationsAst({
+      citations: ["[@zeta20]", "@adams18"],
+      items: [
+        { ...ZETA, id: "zeta20" },
+        { ...ADAMS, id: "adams18" },
+      ],
+      styleXml: NOTE_STYLE,
+    });
+
+    expect(citeInlines(plain?.content ?? []).map((inline) => inline.t)).toEqual(
+      ["Note"],
+    );
+    expect(plainText(plain?.content ?? [])).toBe(
+      "Ann Zeta, A study of nothing.",
+    );
+    // The author stays in the running text, with the note beside it.
+    expect(
+      citeInlines(authorInText?.content ?? []).map((inline) => inline.t),
+    ).toEqual(["Str", "Space", "Str", "Note"]);
+  });
+
+  it("refuses an answer that does not cover every citation", async () => {
+    const rendering = engine.renderCitationsAst({
+      citations: ["[@zeta20]", ""],
+      items: [{ ...ZETA, id: "zeta20" }],
+    });
+
+    await expect(rendering).rejects.toThrow(CitationEngineError);
+    await expect(rendering).rejects.toThrow("formatted 1 of 2 citations");
+  });
+
+  it("renders nothing typed for an empty request", async () => {
+    await expect(
+      engine.renderCitationsAst({ citations: [], items: [] }),
+    ).resolves.toEqual([]);
   });
 
   it("converts a document with a resolve map into docx bytes", async () => {

--- a/apps/obsidian/src/services/pandoc/engine.test.ts
+++ b/apps/obsidian/src/services/pandoc/engine.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment happy-dom
 import { readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
@@ -92,8 +91,8 @@ end
 
 /**
  * A style that lays an entry out as several blocks: `display="block"` and
- * `display="indent"` are what put a `csl-block` and a `csl-indent` around a
- * part of an entry, which the sidebar flattens back into one flow.
+ * `display="indent"` are what put a `csl-block` and a `csl-indent` span around
+ * a part of an entry, which the renderer lays out as it sees fit.
  */
 const BLOCK_STYLE = `<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0">
@@ -106,27 +105,6 @@ const BLOCK_STYLE = `<?xml version="1.0" encoding="utf-8"?>
   <bibliography>
     <layout>
       <names variable="author" display="block"><name/></names>
-      <text variable="title" display="indent"/>
-    </layout>
-  </bibliography>
-</style>`;
-
-/**
- * A style that lays a block out beside a marker: a flush layout puts the rest
- * of the entry in a second column, so its blocks nest one level deeper.
- */
-const NESTED_BLOCK_STYLE = `<?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0">
-  <info>
-    <title>Blocked and numbered</title>
-    <id>http://example.com/blocked-numbered</id>
-    <updated>2020-01-01T00:00:00+00:00</updated>
-  </info>
-  <citation><layout><text variable="citation-number" prefix="[" suffix="]"/></layout></citation>
-  <bibliography second-field-align="flush">
-    <layout>
-      <text variable="citation-number" prefix="[" suffix="]"/>
-      <names variable="author"><name/></names>
       <text variable="title" display="indent"/>
     </layout>
   </bibliography>
@@ -244,176 +222,8 @@ describe("createCitationEngine", { timeout: TIMEOUT }, () => {
     return () => engine[Symbol.asyncDispose]();
   });
 
-  it("renders one bibliography entry per item, keyed by CSL id", async () => {
-    const entries = await engine.renderBibliography({ items: [ZETA, ADAMS] });
-
-    expect(entries.map((entry) => entry.id).toSorted()).toEqual([
-      ZETA.id,
-      ADAMS.id,
-    ]);
-    expect(
-      entries.find((entry) => entry.id === ZETA.id)?.content.textContent,
-    ).toContain("Zeta, Ann");
-  });
-
-  it("formats entries with the supplied CSL style", async () => {
-    const [first] = await engine.renderBibliography({
-      items: [ZETA],
-      styleXml: NUMERIC_STYLE,
-    });
-
-    expect(first?.id).toBe(ZETA.id);
-    expect(first?.content.textContent).toContain("A study of nothing");
-  });
-
-  it("hands the entry marker over apart from the entry text", async () => {
-    const [first] = await engine.renderBibliography({
-      items: [ZETA],
-      styleXml: NUMERIC_STYLE,
-    });
-
-    expect(first?.marker).toBe("[1]");
-    expect(first?.content.textContent).not.toContain("[1]");
-  });
-
-  it("leaves the marker unset for a style that renders none", async () => {
-    const entries = await engine.renderBibliography({ items: [ZETA] });
-
-    expect(entries[0]?.marker).toBeUndefined();
-  });
-
-  it("returns entries in the style's bibliography order", async () => {
-    const entries = await engine.renderBibliography({ items: [ZETA, ADAMS] });
-
-    // The embedded style sorts by author, so Adams leads whatever order the
-    // items arrived in.
-    expect(entries.map((entry) => entry.id)).toEqual([ADAMS.id, ZETA.id]);
-  });
-
-  it("flattens the blocks of an entry into one inline flow", async () => {
-    const [first] = await engine.renderBibliography({
-      items: [ZETA],
-      styleXml: BLOCK_STYLE,
-    });
-
-    expect(first?.content.textContent).toBe("Ann Zeta A study of nothing");
-    expect(first?.content.querySelector("div")).toBeNull();
-  });
-
-  it("flattens the blocks a flush layout nests beside the marker", async () => {
-    const [first] = await engine.renderBibliography({
-      items: [ZETA],
-      styleXml: NESTED_BLOCK_STYLE,
-    });
-
-    expect(first?.marker).toBe("[1]");
-    expect(first?.content.textContent).toBe("Ann Zeta A study of nothing");
-    expect(first?.content.querySelector("div")).toBeNull();
-  });
-
-  it("keeps the markup a style formats an entry's text with", async () => {
-    const [first] = await engine.renderBibliography({ items: [ZETA] });
-
-    // The embedded style italicizes a book title.
-    expect(first?.content.querySelector("em")?.textContent).toBe(
-      "A Study of Nothing",
-    );
-  });
-
-  it("renders no entries for an empty item set", async () => {
-    await expect(engine.renderBibliography({ items: [] })).resolves.toEqual([]);
-  });
-
-  /**
-   * `itemToCsl` addresses an item by its Zotero URI, which is long enough that
-   * Pandoc's default line wrapping would break the opening tag of the entry.
-   */
-  it("keys entries by a Zotero URI id", async () => {
-    const item: CslItemData = { ...ZETA, id: ZOTERO_URI_ID };
-    const entries = await engine.renderBibliography({ items: [item] });
-
-    expect(entries.map((entry) => entry.id)).toEqual([ZOTERO_URI_ID]);
-    expect(entries[0]?.content.textContent).toContain("Zeta, Ann");
-  });
-
-  it("keys entries by a Zotero URI id under a numbered style", async () => {
-    const item: CslItemData = { ...ZETA, id: ZOTERO_URI_ID };
-    const entries = await engine.renderBibliography({
-      items: [item],
-      styleXml: NUMERIC_STYLE,
-    });
-
-    expect(entries.map((entry) => entry.id)).toEqual([ZOTERO_URI_ID]);
-    expect(entries[0]?.marker).toBe("[1]");
-  });
-
-  it("reports the Pandoc failure for an unusable style", async () => {
-    await expect(
-      engine.renderBibliography({ items: [ZETA], styleXml: "<not-a-style/>" }),
-    ).rejects.toThrow(CitationEngineError);
-  });
-
-  it("formats one citation per source, in the order they were asked for", async () => {
-    const rendered = await engine.renderCitations({
-      citations: ["[@zeta20]", "@adams18"],
-      items: [
-        { ...ZETA, id: "zeta20" },
-        { ...ADAMS, id: "adams18" },
-      ],
-    });
-
-    expect(rendered).toHaveLength(2);
-    expect(rendered[0]?.textContent).toContain("Zeta");
-    expect(rendered[1]?.textContent).toContain("Adams");
-  });
-
-  it("keeps the prefix, locator, and author suppression of a cluster", async () => {
-    const [cluster] = await engine.renderCitations({
-      citations: ["[see @zeta20, p. 3; -@adams18]"],
-      items: [
-        { ...ZETA, id: "zeta20" },
-        { ...ADAMS, id: "adams18" },
-      ],
-    });
-
-    // The embedded style renders a page locator bare, so `p.` is not in it.
-    expect(cluster?.textContent).toBe("(see Zeta 2020, 3; 2018)");
-  });
-
-  it("numbers citations across the whole request under a numbered style", async () => {
-    const rendered = await engine.renderCitations({
-      citations: ["[@zeta20]", "[@adams18]", "[@zeta20]"],
-      items: [
-        { ...ZETA, id: "zeta20" },
-        { ...ADAMS, id: "adams18" },
-      ],
-      styleXml: NUMERIC_STYLE,
-    });
-
-    expect(rendered.map((citation) => citation.textContent)).toEqual([
-      "[1]",
-      "[2]",
-      "[1]",
-    ]);
-  });
-
-  it("leaves the bibliography out of a citation render", async () => {
-    const [only] = await engine.renderCitations({
-      citations: ["[@zeta20]"],
-      items: [{ ...ZETA, id: "zeta20" }],
-    });
-
-    expect(only?.textContent).not.toContain("A study of nothing");
-  });
-
-  it("renders nothing for an empty request", async () => {
-    expect(await engine.renderCitations({ citations: [], items: [] })).toEqual(
-      [],
-    );
-  });
-
   it("hands the bibliography over as typed inlines, in the style's order", async () => {
-    const entries = await engine.renderBibliographyAst({
+    const entries = await engine.renderBibliography({
       items: [ZETA, ADAMS],
     });
 
@@ -421,8 +231,8 @@ describe("createCitationEngine", { timeout: TIMEOUT }, () => {
     expect(plainText(entries.at(1)?.content ?? [])).toContain("Zeta, Ann");
   });
 
-  it("keys typed entries by a Zotero URI id", async () => {
-    const entries = await engine.renderBibliographyAst({
+  it("keys entries by a Zotero URI id", async () => {
+    const entries = await engine.renderBibliography({
       items: [{ ...ZETA, id: ZOTERO_URI_ID }],
       styleXml: NUMERIC_STYLE,
     });
@@ -431,7 +241,7 @@ describe("createCitationEngine", { timeout: TIMEOUT }, () => {
   });
 
   it("splits the entry marker off as inlines, without the separator space", async () => {
-    const [first] = await engine.renderBibliographyAst({
+    const [first] = await engine.renderBibliography({
       items: [ZETA],
       styleXml: NUMERIC_STYLE,
     });
@@ -442,15 +252,15 @@ describe("createCitationEngine", { timeout: TIMEOUT }, () => {
     );
   });
 
-  it("leaves the typed marker unset for a style that renders none", async () => {
-    const [first] = await engine.renderBibliographyAst({ items: [ZETA] });
+  it("leaves the marker unset for a style that renders none", async () => {
+    const [first] = await engine.renderBibliography({ items: [ZETA] });
 
     expect(first?.marker).toBeUndefined();
     expect(plainText(first?.content ?? [])).toContain("Zeta, Ann");
   });
 
   it("passes the display spans of an entry through untouched", async () => {
-    const [first] = await engine.renderBibliographyAst({
+    const [first] = await engine.renderBibliography({
       items: [ZETA],
       styleXml: BLOCK_STYLE,
     });
@@ -462,14 +272,29 @@ describe("createCitationEngine", { timeout: TIMEOUT }, () => {
     ).toEqual([["csl-block"], ["csl-indent"]]);
   });
 
-  it("renders no typed entries for an empty item set", async () => {
-    await expect(engine.renderBibliographyAst({ items: [] })).resolves.toEqual(
-      [],
-    );
+  it("keeps the markup a style formats an entry's text with", async () => {
+    const [first] = await engine.renderBibliography({ items: [ZETA] });
+
+    // The embedded style italicizes a book title.
+    expect(
+      first?.content.flatMap((inline) =>
+        inline.t === "Emph" ? [plainText(inline.c)] : [],
+      ),
+    ).toEqual(["A Study of Nothing"]);
   });
 
-  it("formats one typed citation per source, in the order they were asked for", async () => {
-    const rendered = await engine.renderCitationsAst({
+  it("reports the Pandoc failure for an unusable style", async () => {
+    await expect(
+      engine.renderBibliography({ items: [ZETA], styleXml: "<not-a-style/>" }),
+    ).rejects.toThrow(CitationEngineError);
+  });
+
+  it("renders no entries for an empty item set", async () => {
+    await expect(engine.renderBibliography({ items: [] })).resolves.toEqual([]);
+  });
+
+  it("formats one citation per source, in the order they were asked for", async () => {
+    const rendered = await engine.renderCitations({
       citations: ["[@zeta20]", "@adams18"],
       items: [
         { ...ZETA, id: "zeta20" },
@@ -488,7 +313,7 @@ describe("createCitationEngine", { timeout: TIMEOUT }, () => {
   });
 
   it("names every work a cluster cites, in the mode it cites it", async () => {
-    const [cluster] = await engine.renderCitationsAst({
+    const [cluster] = await engine.renderCitations({
       citations: ["[see @zeta20, p. 3; -@adams18]"],
       items: [
         { ...ZETA, id: "zeta20" },
@@ -503,8 +328,8 @@ describe("createCitationEngine", { timeout: TIMEOUT }, () => {
     expect(plainText(cluster?.content ?? [])).toBe("(see Zeta 2020, 3; 2018)");
   });
 
-  it("numbers typed citations across the whole request under a numbered style", async () => {
-    const rendered = await engine.renderCitationsAst({
+  it("numbers citations across the whole request under a numbered style", async () => {
+    const rendered = await engine.renderCitations({
       citations: ["[@zeta20]", "[@adams18]", "[@zeta20]"],
       items: [
         { ...ZETA, id: "zeta20" },
@@ -520,8 +345,17 @@ describe("createCitationEngine", { timeout: TIMEOUT }, () => {
     ]);
   });
 
+  it("leaves the bibliography out of a citation render", async () => {
+    const [only] = await engine.renderCitations({
+      citations: ["[@zeta20]"],
+      items: [{ ...ZETA, id: "zeta20" }],
+    });
+
+    expect(plainText(only?.content ?? [])).not.toContain("A study of nothing");
+  });
+
   it("renders each occurrence of one source by its place in the request", async () => {
-    const rendered = await engine.renderCitationsAst({
+    const rendered = await engine.renderCitations({
       citations: ["[@zeta20]", "[@zeta20]"],
       items: [{ ...ZETA, id: "zeta20" }],
       styleXml: POSITION_STYLE,
@@ -534,7 +368,7 @@ describe("createCitationEngine", { timeout: TIMEOUT }, () => {
   });
 
   it("carries a note-class style's footnote in the citation content", async () => {
-    const [plain, authorInText] = await engine.renderCitationsAst({
+    const [plain, authorInText] = await engine.renderCitations({
       citations: ["[@zeta20]", "@adams18"],
       items: [
         { ...ZETA, id: "zeta20" },
@@ -556,7 +390,7 @@ describe("createCitationEngine", { timeout: TIMEOUT }, () => {
   });
 
   it("refuses an answer that does not cover every citation", async () => {
-    const rendering = engine.renderCitationsAst({
+    const rendering = engine.renderCitations({
       citations: ["[@zeta20]", ""],
       items: [{ ...ZETA, id: "zeta20" }],
     });
@@ -565,9 +399,9 @@ describe("createCitationEngine", { timeout: TIMEOUT }, () => {
     await expect(rendering).rejects.toThrow("formatted 1 of 2 citations");
   });
 
-  it("renders nothing typed for an empty request", async () => {
+  it("renders nothing for an empty request", async () => {
     await expect(
-      engine.renderCitationsAst({ citations: [], items: [] }),
+      engine.renderCitations({ citations: [], items: [] }),
     ).resolves.toEqual([]);
   });
 

--- a/apps/obsidian/src/services/pandoc/engine.test.ts
+++ b/apps/obsidian/src/services/pandoc/engine.test.ts
@@ -157,6 +157,34 @@ const NOTE_STYLE = `<?xml version="1.0" encoding="utf-8"?>
   </bibliography>
 </style>`;
 
+/**
+ * A position-dependent in-text style: a work cited again reads as the
+ * subsequent form, so two occurrences of one source render differently.
+ */
+const POSITION_STYLE = `<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0">
+  <info>
+    <title>Positional</title>
+    <id>http://example.com/positional</id>
+    <updated>2020-01-01T00:00:00+00:00</updated>
+  </info>
+  <citation>
+    <layout>
+      <choose>
+        <if position="subsequent">
+          <text value="ibid."/>
+        </if>
+        <else>
+          <names variable="author"><name form="short"/></names>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography>
+    <layout><names variable="author"><name/></names></layout>
+  </bibliography>
+</style>`;
+
 const RESOLVE_MAP = JSON.stringify({ citations: { "Zeta 2020": ZETA.id } });
 const DOCUMENT = "Cited here [[Zeta 2020]].\n\n# References\n";
 
@@ -489,6 +517,19 @@ describe("createCitationEngine", { timeout: TIMEOUT }, () => {
       "[1]",
       "[2]",
       "[1]",
+    ]);
+  });
+
+  it("renders each occurrence of one source by its place in the request", async () => {
+    const rendered = await engine.renderCitationsAst({
+      citations: ["[@zeta20]", "[@zeta20]"],
+      items: [{ ...ZETA, id: "zeta20" }],
+      styleXml: POSITION_STYLE,
+    });
+
+    expect(rendered.map((citation) => plainText(citation.content))).toEqual([
+      "Zeta",
+      "ibid.",
     ]);
   });
 

--- a/apps/obsidian/src/services/pandoc/engine.ts
+++ b/apps/obsidian/src/services/pandoc/engine.ts
@@ -6,6 +6,13 @@ import type { CslItemData } from "@zotlit/db";
 
 import { getLogger } from "@/lib/log";
 
+import type {
+  Blocks,
+  CitationMode as AstCitationMode,
+  Inline,
+  Inlines,
+  Pandoc,
+} from "./ast";
 import { createPandocRuntime } from "./runtime";
 import type {
   PandocConvertResult,
@@ -46,6 +53,45 @@ export interface BibliographyEntry {
    * of re-parsing markup.
    */
   content: DocumentFragment;
+}
+
+/**
+ * One rendered bibliography entry, as typed AST.
+ *
+ * The counterpart of {@link BibliographyEntry} on the AST path, which the HTML
+ * path gives way to once every consumer reads AST.
+ */
+export interface AstBibliographyEntry {
+  /** CSL `id` of the item this entry renders. */
+  readonly id: string;
+  /**
+   * The Entry Marker the style rendered ahead of the entry, without the space
+   * that separates it from the entry text, or `undefined` for a style that
+   * renders none.
+   */
+  readonly marker: Inlines | undefined;
+  /** The formatted entry, without its wrapping element and without the marker. */
+  readonly content: Inlines;
+}
+
+/** How a citation names one of the works it cites. */
+export type CitationMode = "normal" | "author-in-text" | "suppress-author";
+
+/** One work a rendered citation names, in the order the citation names it. */
+export interface CitedWork {
+  /**
+   * The CSL id the source cites the work by. It is a citekey spelling, so it
+   * repeats across citations and never identifies a citation on its own.
+   */
+  readonly id: string;
+  readonly mode: CitationMode;
+}
+
+/** One rendered in-text citation, as typed AST. */
+export interface RenderedCitation {
+  /** The formatted citation wholesale, the style's own affixes included. */
+  readonly content: Inlines;
+  readonly citations: readonly CitedWork[];
 }
 
 export interface CitationRequest extends SupersedableRequest {
@@ -93,8 +139,23 @@ export interface CitationEngine extends AsyncDisposable {
   renderBibliography(
     request: BibliographyRequest,
   ): Promise<BibliographyEntry[]>;
+  /**
+   * The same bibliography as typed AST, which a consumer holds and shares as a
+   * value instead of cloning it into place.
+   */
+  renderBibliographyAst(
+    request: BibliographyRequest,
+  ): Promise<readonly AstBibliographyEntry[]>;
   /** @returns one formatted citation per requested source, in the same order. */
   renderCitations(request: CitationRequest): Promise<DocumentFragment[]>;
+  /**
+   * The same citations as typed AST, each paired with the works it names.
+   *
+   * @returns one rendered citation per requested source, in the same order.
+   */
+  renderCitationsAst(
+    request: CitationRequest,
+  ): Promise<readonly RenderedCitation[]>;
   renderDocument(request: DocumentRequest): Promise<Uint8Array>;
 }
 
@@ -146,16 +207,48 @@ class PandocCitationEngine implements CitationEngine {
     this.#runtime = runtime;
   }
 
-  async renderBibliography({
-    items,
-    styleXml,
-    supersedes,
-  }: BibliographyRequest): Promise<BibliographyEntry[]> {
+  async renderBibliography(
+    request: BibliographyRequest,
+  ): Promise<BibliographyEntry[]> {
+    return parseBibliography(await this.#formatBibliography(request, "html"));
+  }
+
+  async renderBibliographyAst(
+    request: BibliographyRequest,
+  ): Promise<readonly AstBibliographyEntry[]> {
+    return extractBibliography(
+      parseAst(await this.#formatBibliography(request, "json")),
+    );
+  }
+
+  async renderCitations(request: CitationRequest): Promise<DocumentFragment[]> {
+    if (request.citations.length === 0) return [];
+    return parseCitations(
+      await this.#formatCitations(request, "html"),
+      request.citations.length,
+    );
+  }
+
+  async renderCitationsAst(
+    request: CitationRequest,
+  ): Promise<readonly RenderedCitation[]> {
+    if (request.citations.length === 0) return [];
+    return extractCitations(
+      parseAst(await this.#formatCitations(request, "json")),
+      request.citations.length,
+    );
+  }
+
+  /** @returns Pandoc's `to` output for the whole bibliography of `items`. */
+  async #formatBibliography(
+    { items, styleXml, supersedes }: BibliographyRequest,
+    to: "html" | "json",
+  ): Promise<string> {
     const style = styleInput(styleXml);
     const { stdout } = await this.#convert({
       options: {
         from: "csljson",
-        to: "html",
+        to,
         standalone: false,
         filters: ["citeproc"],
         // Entry markup is stored and re-inserted as HTML, so single-line output
@@ -167,21 +260,19 @@ class PandocCitationEngine implements CitationEngine {
       files: style.files,
       supersedes,
     });
-    return parseBibliography(stdout);
+    return stdout;
   }
 
-  async renderCitations({
-    citations,
-    items,
-    styleXml,
-    supersedes,
-  }: CitationRequest): Promise<DocumentFragment[]> {
-    if (citations.length === 0) return [];
+  /** @returns Pandoc's `to` output for every citation the request names. */
+  async #formatCitations(
+    { citations, items, styleXml, supersedes }: CitationRequest,
+    to: "html" | "json",
+  ): Promise<string> {
     const style = styleInput(styleXml);
     const { stdout } = await this.#convert({
       options: {
         from: MARKDOWN_READER,
-        to: "html",
+        to,
         standalone: false,
         filters: ["citeproc"],
         bibliography: [BIBLIOGRAPHY_FILE],
@@ -198,7 +289,7 @@ class PandocCitationEngine implements CitationEngine {
       },
       supersedes,
     });
-    return parseCitations(stdout, citations.length);
+    return stdout;
   }
 
   async renderDocument({
@@ -417,4 +508,137 @@ function hasClass(node: Node, name: string): boolean {
 /** Text that carries no content of its own, so it reads as a separator. */
 function isWhitespace(node: Node): boolean {
   return node.nodeType === Node.TEXT_NODE && !node.textContent?.trim();
+}
+
+/**
+ * The document envelope stops here: the engine hands over domain shapes, so no
+ * consumer ever holds a {@link Pandoc}.
+ */
+function parseAst(stdout: string): Blocks {
+  return (JSON.parse(stdout) as Pandoc).blocks;
+}
+
+const CITATION_MODES = {
+  NormalCitation: "normal",
+  AuthorInText: "author-in-text",
+  SuppressAuthor: "suppress-author",
+} as const satisfies Record<AstCitationMode["t"], CitationMode>;
+
+/**
+ * Each requested citation is fed as a paragraph of its own, so Pandoc answers
+ * with one paragraph per citation in the order they were asked for. That
+ * position is the join: a `citationId` is a citekey spelling, which repeats
+ * across citations and names no one of them.
+ *
+ * @throws {CitationEngineError} when the output does not answer every citation,
+ *   which would silently misalign the answers with what was asked.
+ */
+function extractCitations(
+  blocks: Blocks,
+  expected: number,
+): RenderedCitation[] {
+  const paragraphs = blocks.flatMap((block) =>
+    block.t === "Para" || block.t === "Plain" ? [block.c] : [],
+  );
+  if (paragraphs.length !== expected) {
+    throw new CitationEngineError(
+      `Pandoc formatted ${paragraphs.length} of ${expected} citations`,
+    );
+  }
+  return paragraphs.map((content) => ({
+    content,
+    citations: collectCitations(content, []),
+  }));
+}
+
+/**
+ * The prefix, suffix, note number, and hash a `Citation` carries are left
+ * behind: the first two are already rendered into the citation's own content,
+ * and the other two name Pandoc's bookkeeping rather than the cited work.
+ */
+function collectCitations(inlines: Inlines, into: CitedWork[]): CitedWork[] {
+  for (const inline of inlines) {
+    if (inline.t === "Cite") {
+      for (const { citationId, citationMode } of inline.c[0]) {
+        into.push({ id: citationId, mode: CITATION_MODES[citationMode.t] });
+      }
+    }
+    collectCitations(nestedInlines(inline), into);
+  }
+  return into;
+}
+
+/** The inlines a constructor carries, so the walk reaches every citation. */
+function nestedInlines(inline: Inline): Inlines {
+  switch (inline.t) {
+    case "Emph":
+    case "Underline":
+    case "Strong":
+    case "Strikeout":
+    case "Superscript":
+    case "Subscript":
+    case "SmallCaps":
+      return inline.c;
+    case "Quoted":
+    case "Cite":
+    case "Link":
+    case "Image":
+    case "Span":
+      return inline.c[1];
+    case "Note":
+      return blockInlines(inline.c);
+    default:
+      return [];
+  }
+}
+
+/**
+ * Pandoc wraps every bibliography entry in a `Div` whose id is the CSL id of
+ * the item behind {@link ENTRY_ID_PREFIX}, inside one `refs` Div, and reports
+ * the entries in the style's own bibliography order. The outer Div's layout
+ * attributes stay behind until a caller asks for them.
+ */
+function extractBibliography(blocks: Blocks): AstBibliographyEntry[] {
+  return blocks.flatMap((block) => {
+    if (block.t !== "Div") return [];
+    const [[id], nested] = block.c;
+    if (!id.startsWith(ENTRY_ID_PREFIX)) return extractBibliography(nested);
+    return {
+      id: id.slice(ENTRY_ID_PREFIX.length),
+      ...splitAstEntry(blockInlines(nested)),
+    };
+  });
+}
+
+/**
+ * Take the Entry Marker off the front of an entry. A flush layout opens the
+ * entry with the left-margin span, which holds the marker and the space that
+ * sets the second column off from it — the space is layout, not marker. Every
+ * other `csl-*` span passes through, since how they lay an entry out is the
+ * renderer's policy.
+ */
+function splitAstEntry(
+  inlines: Inlines,
+): Pick<AstBibliographyEntry, "marker" | "content"> {
+  const [first, ...rest] = inlines;
+  if (first?.t !== "Span" || !first.c[0][1].includes(LEFT_MARGIN_CLASS)) {
+    return { marker: undefined, content: inlines };
+  }
+  const marker = dropTrailingSpace(first.c[1]);
+  return { marker: marker.length > 0 ? marker : undefined, content: rest };
+}
+
+function dropTrailingSpace(inlines: Inlines): Inlines {
+  return inlines.at(-1)?.t === "Space" ? inlines.slice(0, -1) : inlines;
+}
+
+/** Unwraps the block envelopes an entry is laid out in, so only inlines leave. */
+function blockInlines(blocks: Blocks): Inlines {
+  return blocks.flatMap((block) => {
+    if (block.t === "Para" || block.t === "Plain") return block.c;
+    logger.debug("Dropped a block the engine cannot unwrap", {
+      block: block.t,
+    });
+    return [];
+  });
 }

--- a/apps/obsidian/src/services/pandoc/engine.ts
+++ b/apps/obsidian/src/services/pandoc/engine.ts
@@ -1,7 +1,5 @@
 // Bibliography and cited-document rendering, behind an interface that hides Pandoc.
 
-import { sanitizeHTMLToDom } from "obsidian";
-
 import type { CslItemData } from "@zotlit/db";
 
 import { getLogger } from "@/lib/log";
@@ -39,29 +37,8 @@ export interface BibliographyRequest extends SupersedableRequest {
   styleXml?: string;
 }
 
+/** One rendered bibliography entry, as typed AST. */
 export interface BibliographyEntry {
-  /** CSL `id` of the item this entry renders. */
-  id: string;
-  /**
-   * The Entry Marker the style rendered ahead of the entry — a citation number
-   * in the style's own affixes — or `undefined` for a style that renders none.
-   */
-  marker: string | undefined;
-  /**
-   * The formatted entry text, without its wrapping element and without the
-   * marker. Already sanitized and parsed, so a consumer inserts a clone instead
-   * of re-parsing markup.
-   */
-  content: DocumentFragment;
-}
-
-/**
- * One rendered bibliography entry, as typed AST.
- *
- * The counterpart of {@link BibliographyEntry} on the AST path, which the HTML
- * path gives way to once every consumer reads AST.
- */
-export interface AstBibliographyEntry {
   /** CSL `id` of the item this entry renders. */
   readonly id: string;
   /**
@@ -136,24 +113,19 @@ export interface DocumentRequest extends SupersedableRequest {
  * ones.
  */
 export interface CitationEngine extends AsyncDisposable {
+  /**
+   * The whole bibliography as typed AST, which a consumer holds and shares as a
+   * value instead of copying it into place.
+   */
   renderBibliography(
     request: BibliographyRequest,
-  ): Promise<BibliographyEntry[]>;
+  ): Promise<readonly BibliographyEntry[]>;
   /**
-   * The same bibliography as typed AST, which a consumer holds and shares as a
-   * value instead of cloning it into place.
-   */
-  renderBibliographyAst(
-    request: BibliographyRequest,
-  ): Promise<readonly AstBibliographyEntry[]>;
-  /** @returns one formatted citation per requested source, in the same order. */
-  renderCitations(request: CitationRequest): Promise<DocumentFragment[]>;
-  /**
-   * The same citations as typed AST, each paired with the works it names.
+   * The citations as typed AST, each paired with the works it names.
    *
    * @returns one rendered citation per requested source, in the same order.
    */
-  renderCitationsAst(
+  renderCitations(
     request: CitationRequest,
   ): Promise<readonly RenderedCitation[]>;
   renderDocument(request: DocumentRequest): Promise<Uint8Array>;
@@ -209,51 +181,35 @@ class PandocCitationEngine implements CitationEngine {
 
   async renderBibliography(
     request: BibliographyRequest,
-  ): Promise<BibliographyEntry[]> {
-    return parseBibliography(await this.#formatBibliography(request, "html"));
-  }
-
-  async renderBibliographyAst(
-    request: BibliographyRequest,
-  ): Promise<readonly AstBibliographyEntry[]> {
+  ): Promise<readonly BibliographyEntry[]> {
     return extractBibliography(
-      parseAst(await this.#formatBibliography(request, "json")),
+      parseAst(await this.#formatBibliography(request)),
     );
   }
 
-  async renderCitations(request: CitationRequest): Promise<DocumentFragment[]> {
-    if (request.citations.length === 0) return [];
-    return parseCitations(
-      await this.#formatCitations(request, "html"),
-      request.citations.length,
-    );
-  }
-
-  async renderCitationsAst(
+  async renderCitations(
     request: CitationRequest,
   ): Promise<readonly RenderedCitation[]> {
     if (request.citations.length === 0) return [];
     return extractCitations(
-      parseAst(await this.#formatCitations(request, "json")),
+      parseAst(await this.#formatCitations(request)),
       request.citations.length,
     );
   }
 
-  /** @returns Pandoc's `to` output for the whole bibliography of `items`. */
-  async #formatBibliography(
-    { items, styleXml, supersedes }: BibliographyRequest,
-    to: "html" | "json",
-  ): Promise<string> {
+  /** @returns Pandoc's JSON output for the whole bibliography of `items`. */
+  async #formatBibliography({
+    items,
+    styleXml,
+    supersedes,
+  }: BibliographyRequest): Promise<string> {
     const style = styleInput(styleXml);
     const { stdout } = await this.#convert({
       options: {
         from: "csljson",
-        to,
+        to: "json",
         standalone: false,
         filters: ["citeproc"],
-        // Entry markup is stored and re-inserted as HTML, so single-line output
-        // keeps it free of the line breaks Pandoc's wrapping would introduce.
-        wrap: "none",
         ...style.options,
       },
       stdin: JSON.stringify(items),
@@ -263,23 +219,24 @@ class PandocCitationEngine implements CitationEngine {
     return stdout;
   }
 
-  /** @returns Pandoc's `to` output for every citation the request names. */
-  async #formatCitations(
-    { citations, items, styleXml, supersedes }: CitationRequest,
-    to: "html" | "json",
-  ): Promise<string> {
+  /** @returns Pandoc's JSON output for every citation the request names. */
+  async #formatCitations({
+    citations,
+    items,
+    styleXml,
+    supersedes,
+  }: CitationRequest): Promise<string> {
     const style = styleInput(styleXml);
     const { stdout } = await this.#convert({
       options: {
         from: MARKDOWN_READER,
-        to,
+        to: "json",
         standalone: false,
         filters: ["citeproc"],
         bibliography: [BIBLIOGRAPHY_FILE],
         // The bibliography is the sidebar's job; this render wants the in-text
         // citations alone.
         metadata: { "suppress-bibliography": true },
-        wrap: "none",
         ...style.options,
       },
       stdin: citations.join("\n\n"),
@@ -395,120 +352,11 @@ function styleInput(styleXml: string | undefined): {
     : { options: { csl: STYLE_FILE }, files: { [STYLE_FILE]: styleXml } };
 }
 
-/**
- * Each requested citation is fed as a paragraph of its own, so Pandoc writes
- * one `<p>` per citation in the order they were asked for. The paragraph's own
- * children are the formatted citation — the style's affixes included — and they
- * are sanitized once here, so neither the style nor an item field can carry
- * active markup into the reading view.
- *
- * @throws {CitationEngineError} when the output does not answer every citation,
- *   which would silently misalign the answers with what was asked.
- */
-function parseCitations(html: string, expected: number): DocumentFragment[] {
-  const paragraphs = sanitizeHTMLToDom(html).querySelectorAll("p");
-  if (paragraphs.length !== expected) {
-    throw new CitationEngineError(
-      `Pandoc formatted ${paragraphs.length} of ${expected} citations`,
-    );
-  }
-  return [...paragraphs].map((paragraph) => {
-    const content = createFragment();
-    content.append(...paragraph.childNodes);
-    return content;
-  });
-}
-
 /** Pandoc prefixes every entry's `id` with this, over the CSL id of the item. */
 const ENTRY_ID_PREFIX = "ref-";
 
-/** The block a style's Entry Marker sits in, when the style renders one. */
+/** The span a style's Entry Marker sits in, when the style renders one. */
 const LEFT_MARGIN_CLASS = "csl-left-margin";
-
-/**
- * The blocks a style lays the rest of an entry out in: the second column of a
- * flush layout, and the two `display` blocks a layout can wrap a part in.
- */
-const ENTRY_BLOCK_CLASSES = ["csl-right-inline", "csl-block", "csl-indent"];
-
-/**
- * Pandoc wraps every bibliography entry in `<div id="ref-ID" class="csl-entry">`
- * inside one `<div id="refs">`, and reports the entries in the style's own
- * bibliography order. Entry markup nests further elements, and a CSL id is a
- * Zotero URI long enough for Pandoc to wrap the opening tag, so the markup is
- * read as a DOM rather than matched as text.
- *
- * The entry keeps that parsed form: it is sanitized once here, so a style or an
- * item field cannot carry active markup into the sidebar, and the view inserts
- * it without a serialize-and-re-parse round trip.
- */
-function parseBibliography(html: string): BibliographyEntry[] {
-  const entries: BibliographyEntry[] = [];
-  for (const entry of sanitizeHTMLToDom(html).querySelectorAll(".csl-entry")) {
-    if (!entry.id.startsWith(ENTRY_ID_PREFIX)) continue;
-    entries.push({
-      id: entry.id.slice(ENTRY_ID_PREFIX.length),
-      ...splitEntry(entry),
-    });
-  }
-  return entries;
-}
-
-/**
- * Take the Entry Marker out of an entry and flatten what is left into one
- * inline flow.
- *
- * A style lays an entry out in blocks, and a block break would push whatever
- * the sidebar puts after the entry — its occurrence counter — onto its own
- * line. Each block hands its own children over instead, separated by one space
- * where the break used to be. A flush layout nests its blocks inside the column
- * beside the marker, so a block hands over what its own blocks hold. Line
- * breaks the markup itself carries between blocks are layout rather than text,
- * so they make that same single space.
- */
-function splitEntry(
-  entry: Element,
-): Pick<BibliographyEntry, "marker" | "content"> {
-  const content = createFragment();
-  let marker: string | undefined;
-
-  /** Moves one level of children over, and recurses through the blocks. */
-  function flatten(parent: Node): void {
-    /** A separator stands between what was emitted and whatever comes next. */
-    let gap = false;
-    // A copy, since appending a node to the flow takes it out of `parent` and
-    // the live child list would shift the ones still to be read.
-    const children = [...parent.childNodes];
-    for (const node of children) {
-      if (isWhitespace(node)) {
-        gap = true;
-        continue;
-      }
-      if (hasClass(node, LEFT_MARGIN_CLASS)) {
-        marker ??= node.textContent?.trim() || undefined;
-        gap = false;
-        continue;
-      }
-      const block = ENTRY_BLOCK_CLASSES.some((name) => hasClass(node, name));
-      if (content.hasChildNodes() && (gap || block)) content.append(" ");
-      if (block) flatten(node);
-      else content.append(node);
-      gap = block;
-    }
-  }
-
-  flatten(entry);
-  return { marker, content };
-}
-
-function hasClass(node: Node, name: string): boolean {
-  return node instanceof Element && node.classList.contains(name);
-}
-
-/** Text that carries no content of its own, so it reads as a separator. */
-function isWhitespace(node: Node): boolean {
-  return node.nodeType === Node.TEXT_NODE && !node.textContent?.trim();
-}
 
 /**
  * The document envelope stops here: the engine hands over domain shapes, so no
@@ -598,14 +446,14 @@ function nestedInlines(inline: Inline): Inlines {
  * the entries in the style's own bibliography order. The outer Div's layout
  * attributes stay behind until a caller asks for them.
  */
-function extractBibliography(blocks: Blocks): AstBibliographyEntry[] {
+function extractBibliography(blocks: Blocks): BibliographyEntry[] {
   return blocks.flatMap((block) => {
     if (block.t !== "Div") return [];
     const [[id], nested] = block.c;
     if (!id.startsWith(ENTRY_ID_PREFIX)) return extractBibliography(nested);
     return {
       id: id.slice(ENTRY_ID_PREFIX.length),
-      ...splitAstEntry(blockInlines(nested)),
+      ...splitEntry(blockInlines(nested)),
     };
   });
 }
@@ -617,9 +465,9 @@ function extractBibliography(blocks: Blocks): AstBibliographyEntry[] {
  * other `csl-*` span passes through, since how they lay an entry out is the
  * renderer's policy.
  */
-function splitAstEntry(
+function splitEntry(
   inlines: Inlines,
-): Pick<AstBibliographyEntry, "marker" | "content"> {
+): Pick<BibliographyEntry, "marker" | "content"> {
   const [first, ...rest] = inlines;
   if (first?.t !== "Span" || !first.c[0][1].includes(LEFT_MARGIN_CLASS)) {
     return { marker: undefined, content: inlines };

--- a/apps/obsidian/src/services/pandoc/inline-content.test.ts
+++ b/apps/obsidian/src/services/pandoc/inline-content.test.ts
@@ -1,0 +1,411 @@
+// @vitest-environment happy-dom
+import { act } from "preact/test-utils";
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Attr, Inline, Inlines } from "./ast";
+
+const logRecords: { level: string; message: string; fields: unknown }[] = [];
+vi.mock("@/lib/log", () => ({
+  getLogger: () => ({
+    debug: (message: string, fields: unknown) =>
+      logRecords.push({ level: "debug", message, fields }),
+    info: (message: string, fields: unknown) =>
+      logRecords.push({ level: "info", message, fields }),
+    warn: (message: string, fields: unknown) =>
+      logRecords.push({ level: "warn", message, fields }),
+    error: (message: string, fields: unknown) =>
+      logRecords.push({ level: "error", message, fields }),
+  }),
+}));
+
+import type { InlineContentProps } from "./inline-content";
+import { InlineContent, renderInlineContent } from "./inline-content";
+
+const NO_ATTR: Attr = ["", [], []];
+
+function str(text: string): Inline {
+  return { t: "Str", c: text };
+}
+
+function span(classes: readonly string[], content: Inlines): Inline {
+  return { t: "Span", c: [["", classes, []], content] };
+}
+
+/** Renders through a React tree the surface owns, as the sidebar does. */
+function attached(props: InlineContentProps): HTMLElement {
+  const container = document.createElement("div");
+  document.body.append(container);
+  // Awaiting would hide the point: the component renders synchronously.
+  void act(() => {
+    createRoot(container).render(createElement(InlineContent, props));
+  });
+  return container;
+}
+
+/** Renders through the adapter, as the raw-DOM surfaces do. */
+function detached(props: InlineContentProps): HTMLElement {
+  const container = document.createElement("div");
+  document.body.append(container);
+  renderInlineContent(container, props);
+  return container;
+}
+
+beforeEach(() => {
+  logRecords.length = 0;
+  document.body.replaceChildren();
+});
+
+describe("InlineContent element vocabulary", () => {
+  it.each([
+    ["Emph", "em"],
+    ["Strong", "strong"],
+    ["Underline", "u"],
+    ["Strikeout", "del"],
+    ["Superscript", "sup"],
+    ["Subscript", "sub"],
+  ] as const)("renders %s as <%s>", (constructor, tag) => {
+    const container = attached({
+      nodes: [{ t: constructor, c: [str("title")] }],
+    });
+
+    expect(container.innerHTML).toBe(`<${tag}>title</${tag}>`);
+  });
+
+  it("renders small caps as a span that asks for them", () => {
+    const container = attached({
+      nodes: [{ t: "SmallCaps", c: [str("ii")] }],
+    });
+
+    const rendered = container.querySelector("span")!;
+    expect(rendered.textContent).toBe("ii");
+    expect(rendered.classList).toContain("zt:[font-variant:small-caps]");
+  });
+
+  it("renders a quotation as its quote characters, in no element", () => {
+    const container = attached({
+      nodes: [
+        { t: "Quoted", c: [{ t: "DoubleQuote" }, [str("Outer")]] },
+        { t: "Space" },
+        { t: "Quoted", c: [{ t: "SingleQuote" }, [str("inner")]] },
+      ],
+    });
+
+    expect(container.textContent).toBe("“Outer” ‘inner’");
+    expect(container.children).toHaveLength(0);
+  });
+
+  it("renders the separators of a flow", () => {
+    const container = attached({
+      nodes: [
+        str("one"),
+        { t: "Space" },
+        str("two"),
+        { t: "SoftBreak" },
+        str("three"),
+        { t: "LineBreak" },
+        str("four"),
+      ],
+    });
+
+    expect(container.innerHTML).toBe("one two three<br>four");
+  });
+
+  it("keeps AST attributes off the DOM", () => {
+    const attr: Attr = ["ref-zeta", ["nocase"], [["data-x", "y"]]];
+    const container = attached({
+      nodes: [
+        { t: "Span", c: [attr, [str("Zeta")]] },
+        { t: "Code", c: [attr, "code"] },
+        { t: "Link", c: [attr, [str("link")], ["https://example.com", ""]] },
+      ],
+    });
+
+    expect(container.querySelector("[id]")).toBeNull();
+    expect(container.querySelector("[data-x]")).toBeNull();
+    expect(container.querySelector(".nocase")).toBeNull();
+    expect(container.querySelector("code")!.className).toBe("");
+  });
+
+  it("renders a citation's own content transparently", () => {
+    const container = attached({
+      nodes: [
+        {
+          t: "Cite",
+          c: [
+            [
+              {
+                citationId: "zeta20",
+                citationPrefix: [],
+                citationSuffix: [],
+                citationMode: { t: "NormalCitation" },
+                citationNoteNum: 1,
+                citationHash: 0,
+              },
+            ],
+            [str("(Zeta"), { t: "Space" }, str("2020)")],
+          ],
+        },
+      ],
+    });
+
+    expect(container.innerHTML).toBe("(Zeta 2020)");
+  });
+});
+
+describe("InlineContent degradation", () => {
+  it("shows the source of a formula as text", () => {
+    const container = attached({
+      nodes: [{ t: "Math", c: [{ t: "InlineMath" }, "e^{i\\pi}"] }],
+    });
+
+    expect(container.innerHTML).toBe("e^{i\\pi}");
+  });
+
+  it("shows code as code", () => {
+    const container = attached({
+      nodes: [{ t: "Code", c: [NO_ATTR, "grep"] }],
+    });
+
+    expect(container.innerHTML).toBe("<code>grep</code>");
+  });
+
+  it("shows an image as its alternative text", () => {
+    const container = attached({
+      nodes: [
+        {
+          t: "Image",
+          c: [
+            NO_ATTR,
+            [str("Cover"), { t: "Space" }, str("art")],
+            ["c.png", "Cover"],
+          ],
+        },
+      ],
+    });
+
+    expect(container.innerHTML).toBe("Cover art");
+  });
+
+  it("drops raw markup and records what it dropped", () => {
+    const container = attached({
+      nodes: [
+        str("before"),
+        { t: "RawInline", c: ["html", "<script>x</script>"] },
+      ],
+    });
+
+    expect(container.innerHTML).toBe("before");
+    expect(logRecords).toEqual([
+      {
+        level: "debug",
+        message: "Dropped an inline the renderer cannot show",
+        fields: { inline: "RawInline", format: "html" },
+      },
+    ]);
+  });
+});
+
+describe("InlineContent span dispatch", () => {
+  it("joins the parts of a laid-out entry with one space apiece", () => {
+    const container = attached({
+      nodes: [
+        span(["csl-left-margin"], [str("1.")]),
+        span(["csl-right-inline"], [str("Zeta,"), { t: "Space" }, str("Ann.")]),
+        span(["csl-block"], [str("A"), { t: "Space" }, str("study.")]),
+        span(["csl-indent"], [str("Nowhere:"), { t: "Space" }, str("Press.")]),
+      ],
+    });
+
+    expect(container.textContent).toBe(
+      "1. Zeta, Ann. A study. Nowhere: Press.",
+    );
+    expect(container.children).toHaveLength(0);
+  });
+
+  it("leaves one space at a boundary the flow already spaces", () => {
+    const container = attached({
+      nodes: [
+        str("Ann."),
+        { t: "Space" },
+        span(["csl-block"], [str("A"), { t: "Space" }, str("study.")]),
+        { t: "Space" },
+        str("Press."),
+      ],
+    });
+
+    expect(container.textContent).toBe("Ann. A study. Press.");
+  });
+
+  it("renders a semantic span's children and nothing of its own", () => {
+    for (const classes of [
+      ["nocase"],
+      ["nodecoration"],
+      [],
+      ["csl-something-new"],
+    ]) {
+      const container = attached({
+        nodes: [span(classes, [str("Zeta"), { t: "Space" }, str("2020")])],
+      });
+
+      expect(container.innerHTML).toBe("Zeta 2020");
+    }
+  });
+});
+
+describe("InlineContent links", () => {
+  it.each(["https://example.com/a", "http://example.com/a", "mailto:a@b.com"])(
+    "renders %s as a bare anchor",
+    (url) => {
+      const container = attached({
+        nodes: [{ t: "Link", c: [NO_ATTR, [str("source")], [url, "Open it"]] }],
+      });
+
+      const anchor = container.querySelector("a")!;
+      expect(anchor.getAttribute("href")).toBe(url);
+      expect(anchor.getAttribute("aria-label")).toBe("Open it");
+      expect(anchor.className).toBe("");
+      expect(anchor.getAttribute("target")).toBeNull();
+      expect(anchor.textContent).toBe("source");
+    },
+  );
+
+  it("leaves a link with no title unlabelled", () => {
+    const container = attached({
+      nodes: [
+        {
+          t: "Link",
+          c: [NO_ATTR, [str("source")], ["https://example.com", ""]],
+        },
+      ],
+    });
+
+    expect(container.innerHTML).toBe(
+      '<a href="https://example.com">source</a>',
+    );
+  });
+
+  it.each([
+    "#ref-zeta",
+    "/vault/note.md",
+    "javascript:alert(1)",
+    "obsidian://open",
+  ])("renders the content alone for the target %s", (url) => {
+    const container = attached({
+      nodes: [{ t: "Link", c: [NO_ATTR, [str("source")], [url, "Open it"]] }],
+    });
+
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toBe("source");
+  });
+
+  it("renders the content alone where a surface suppresses links", () => {
+    const container = attached({
+      links: "suppress",
+      nodes: [
+        {
+          t: "Link",
+          c: [
+            NO_ATTR,
+            [{ t: "Emph", c: [str("A study")] }],
+            ["https://example.com", "Open it"],
+          ],
+        },
+      ],
+    });
+
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.innerHTML).toBe("<em>A study</em>");
+  });
+});
+
+describe("InlineContent entry serials", () => {
+  const noted: Inlines = [
+    str("Zeta"),
+    { t: "Space" },
+    str("(2020)"),
+    {
+      t: "Note",
+      c: [{ t: "Para", c: [str("Ann Zeta, A study of nothing.")] }],
+    },
+  ];
+
+  it("shows one serial per cited work, as plain comma-separated digits", () => {
+    const container = attached({ nodes: noted, serials: [1, 2] });
+
+    const serial = container.querySelector("sup")!;
+    expect(serial.textContent).toBe("1,2");
+    expect(container.textContent).toBe("Zeta (2020)1,2");
+  });
+
+  it("marks the slot of a work the bibliography rendered no entry for", () => {
+    const container = attached({ nodes: noted, serials: [undefined, 2] });
+
+    expect(container.querySelector("sup")!.textContent).toBe("⚠,2");
+  });
+
+  it("drops a note that stands for no serial, and records it", () => {
+    const container = attached({ nodes: noted });
+
+    expect(container.querySelector("sup")).toBeNull();
+    expect(container.textContent).toBe("Zeta (2020)");
+    expect(logRecords).toEqual([
+      {
+        level: "debug",
+        message: "Dropped a note with no serial to stand for it",
+        fields: { inline: "Note" },
+      },
+    ]);
+  });
+
+  it("keeps the note's own text out of the flow", () => {
+    const container = attached({ nodes: noted, serials: [1] });
+
+    expect(container.textContent).not.toContain("A study of nothing");
+  });
+});
+
+// The class is a public promise to themes: an Entry Serial carries it wherever
+// a note-class style puts one inline.
+describe("zt-entry-serial theme hook", () => {
+  it("marks every Entry Serial run, and nothing else", () => {
+    const container = attached({
+      nodes: [
+        { t: "Superscript", c: [str("st")] },
+        { t: "Note", c: [{ t: "Para", c: [str("Ann Zeta.")] }] },
+      ],
+      serials: [3],
+    });
+
+    const marked = [...container.querySelectorAll(".zt-entry-serial")];
+    expect(marked.map((el) => el.textContent)).toEqual(["3"]);
+    expect(marked[0]!.tagName).toBe("SUP");
+  });
+});
+
+describe("renderInlineContent", () => {
+  const nodes: Inlines = [
+    span(["csl-left-margin"], [str("1.")]),
+    span(
+      ["csl-right-inline"],
+      [
+        { t: "Emph", c: [str("A study")] },
+        { t: "Space" },
+        { t: "Link", c: [NO_ATTR, [str("doi")], ["https://doi.org/10", ""]] },
+      ],
+    ),
+  ];
+
+  it("populates the container before it returns", () => {
+    const container = document.createElement("div");
+
+    renderInlineContent(container, { nodes });
+
+    expect(container.textContent).toBe("1. A study doi");
+  });
+
+  it("renders what the component renders inside a tree", () => {
+    expect(detached({ nodes }).innerHTML).toBe(attached({ nodes }).innerHTML);
+  });
+});

--- a/apps/obsidian/src/services/pandoc/inline-content.test.ts
+++ b/apps/obsidian/src/services/pandoc/inline-content.test.ts
@@ -408,4 +408,28 @@ describe("renderInlineContent", () => {
   it("renders what the component renders inside a tree", () => {
     expect(detached({ nodes }).innerHTML).toBe(attached({ nodes }).innerHTML);
   });
+
+  it("reports a render that left the container empty", async () => {
+    vi.resetModules();
+    vi.doMock("react-dom/client", () => ({
+      createRoot: () => ({ render: () => {}, unmount: () => {} }),
+    }));
+    try {
+      const deferred = await import("./inline-content");
+      const container = document.createElement("div");
+
+      deferred.renderInlineContent(container, { nodes });
+
+      expect(logRecords).toEqual([
+        {
+          level: "error",
+          message: "Detached render left the container empty",
+          fields: { inlines: nodes.length },
+        },
+      ]);
+    } finally {
+      vi.doUnmock("react-dom/client");
+      vi.resetModules();
+    }
+  });
 });

--- a/apps/obsidian/src/services/pandoc/inline-content.test.ts
+++ b/apps/obsidian/src/services/pandoc/inline-content.test.ts
@@ -363,6 +363,25 @@ describe("InlineContent entry serials", () => {
 
     expect(container.textContent).not.toContain("A study of nothing");
   });
+
+  // An accepted limitation: a note a reader wrote themselves, in a citation
+  // prefix, is a note like any other here, so it shows the cluster's serials
+  // rather than its own text.
+  it("shows the cluster's serials for a note the reader wrote in a prefix", () => {
+    const container = attached({
+      nodes: [
+        { t: "Note", c: [{ t: "Para", c: [str("An aside of my own.")] }] },
+        { t: "Space" },
+        ...noted,
+      ],
+      serials: [1, 2],
+    });
+
+    expect(
+      [...container.querySelectorAll("sup")].map((run) => run.textContent),
+    ).toEqual(["1,2", "1,2"]);
+    expect(container.textContent).not.toContain("An aside of my own.");
+  });
 });
 
 // The class is a public promise to themes: an Entry Serial carries it wherever

--- a/apps/obsidian/src/services/pandoc/inline-content.test.ts
+++ b/apps/obsidian/src/services/pandoc/inline-content.test.ts
@@ -300,7 +300,7 @@ describe("InlineContent links", () => {
     expect(container.textContent).toBe("source");
   });
 
-  it("renders the content alone where a surface suppresses links", () => {
+  it("renders the content as plain text where a surface suppresses links", () => {
     const container = attached({
       links: "suppress",
       nodes: [
@@ -308,15 +308,14 @@ describe("InlineContent links", () => {
           t: "Link",
           c: [
             NO_ATTR,
-            [{ t: "Emph", c: [str("A study")] }],
+            [{ t: "Emph", c: [str("A study")] }, { t: "Space" }, str("(2020)")],
             ["https://example.com", "Open it"],
           ],
         },
       ],
     });
 
-    expect(container.querySelector("a")).toBeNull();
-    expect(container.innerHTML).toBe("<em>A study</em>");
+    expect(container.innerHTML).toBe("A study (2020)");
   });
 });
 
@@ -407,6 +406,15 @@ describe("renderInlineContent", () => {
 
   it("renders what the component renders inside a tree", () => {
     expect(detached({ nodes }).innerHTML).toBe(attached({ nodes }).innerHTML);
+  });
+
+  it("passes a flow that has nothing to show", () => {
+    const container = detached({
+      nodes: [{ t: "RawInline", c: ["html", "<b>"] }],
+    });
+
+    expect(container.hasChildNodes()).toBe(false);
+    expect(logRecords.map((record) => record.level)).toEqual(["debug"]);
   });
 
   it("reports a render that left the container empty", async () => {

--- a/apps/obsidian/src/services/pandoc/inline-content.tsx
+++ b/apps/obsidian/src/services/pandoc/inline-content.tsx
@@ -266,6 +266,39 @@ function renderFlow(nodes: Inlines, context: Context): ReactNode[] {
 }
 
 /**
+ * Whether a flow holds a note — the footnote a note-class Citation and
+ * References Style writes a citation as, which no surface of a document can
+ * show and an Entry Serial run stands in for.
+ *
+ * It is the one signal that puts a document on Entry Serials: a surface reads
+ * it off what the engine rendered, rather than off the style that rendered it.
+ */
+export function holdsNote(nodes: Inlines): boolean {
+  return nodes.some((inline) => {
+    switch (inline.t) {
+      case "Note":
+        return true;
+      case "Emph":
+      case "Strong":
+      case "Underline":
+      case "Strikeout":
+      case "Superscript":
+      case "Subscript":
+      case "SmallCaps":
+        return holdsNote(inline.c);
+      case "Quoted":
+      case "Cite":
+      case "Link":
+      case "Image":
+      case "Span":
+        return holdsNote(inline.c[1]);
+      default:
+        return false;
+    }
+  });
+}
+
+/**
  * The text one flow reads as, for a destination that takes no elements at all —
  * an Entry Marker written beside plain text, above all.
  */

--- a/apps/obsidian/src/services/pandoc/inline-content.tsx
+++ b/apps/obsidian/src/services/pandoc/inline-content.tsx
@@ -6,6 +6,7 @@ import { createRoot } from "react-dom/client";
 
 import { getLogger } from "@/lib/log";
 import { themeHook } from "@/lib/theme-hooks";
+import { tooltipAttrs } from "@/lib/utils";
 
 import type { Inlines, QuoteType } from "./ast";
 
@@ -53,15 +54,21 @@ export function InlineContent({
  * the reading-view and editor surfaces that build their DOM by hand.
  *
  * The render populates `container` before this returns, so the caller hands the
- * container straight back to Obsidian. The root is then left alone: the
- * component holds no effects to clean up, and the container dies with the DOM
- * its surface inserted it into.
+ * container straight back to Obsidian. That population is asserted rather than
+ * assumed: a container still empty here means the render deferred its commit,
+ * and every surface is handing Obsidian an element it never fills. The root is
+ * then left alone: the component holds no effects to clean up, and the
+ * container dies with the DOM its surface inserted it into.
  */
 export function renderInlineContent(
   container: Element,
   props: InlineContentProps,
 ): void {
   createRoot(container).render(<InlineContent {...props} />);
+  if (container.hasChildNodes()) return;
+  logger.error("Detached render left the container empty", {
+    inlines: props.nodes.length,
+  });
 }
 
 interface Context {
@@ -213,7 +220,7 @@ function renderFlow(nodes: Inlines, context: Context): ReactNode[] {
             break;
           }
           add(
-            <a key={key++} href={href} aria-label={title || undefined}>
+            <a key={key++} href={href} {...(title ? tooltipAttrs(title) : {})}>
               {renderFlow(children, context)}
             </a>,
           );

--- a/apps/obsidian/src/services/pandoc/inline-content.tsx
+++ b/apps/obsidian/src/services/pandoc/inline-content.tsx
@@ -266,6 +266,14 @@ function renderFlow(nodes: Inlines, context: Context): ReactNode[] {
 }
 
 /**
+ * The text one flow reads as, for a destination that takes no elements at all —
+ * an Entry Marker written beside plain text, above all.
+ */
+export function inlineText(nodes: Inlines): string {
+  return plainText(nodes, contextOf({ nodes }));
+}
+
+/**
  * The text one flow reads as, with every element it would render left out —
  * how a link shows its content where the surface suppresses anchors, since the
  * anchor that surface inserts into carries the text as its own.

--- a/apps/obsidian/src/services/pandoc/inline-content.tsx
+++ b/apps/obsidian/src/services/pandoc/inline-content.tsx
@@ -1,0 +1,260 @@
+// The one rendering of a formatted inline flow, shared by every surface that shows citations.
+
+import type { ReactNode } from "react";
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+
+import { getLogger } from "@/lib/log";
+import { themeHook } from "@/lib/theme-hooks";
+
+import type { Inlines, QuoteType } from "./ast";
+
+const logger = getLogger(["pandoc", "renderer"]);
+
+export interface InlineContentProps {
+  /** The formatted flow, as the engine handed it over. */
+  nodes: Inlines;
+  /**
+   * One slot per work the citation names, in the order it names them; a slot is
+   * `undefined` where the bibliography rendered no entry for that work. Left
+   * unset by a flow that is not a citation's, which drops any `Note` it holds.
+   */
+  serials?: readonly (number | undefined)[];
+  /**
+   * Whether a link target reaches the DOM as an anchor. A surface that inserts
+   * into an anchor of its own suppresses them, since nesting one anchor in
+   * another is invalid; the link's own content still shows.
+   * @default "render"
+   */
+  links?: "render" | "suppress";
+}
+
+/**
+ * Show one formatted inline flow — a rendered citation, a bibliography entry,
+ * or either one's Entry Marker.
+ *
+ * The component owns no wrapper: it renders the flow's own elements and nothing
+ * around them, so each surface keeps the element and the classes it already
+ * inserts into. It is pure by contract — props in, elements out, no hooks, no
+ * subscriptions, no portals — which is what lets the raw-DOM surfaces render it
+ * detached and never unmount it. Text reaches the DOM as text alone: nothing a
+ * style or an item field carries is ever read as markup.
+ */
+export function InlineContent({
+  nodes,
+  serials,
+  links = "render",
+}: InlineContentProps) {
+  return <>{renderFlow(nodes, { serials, links })}</>;
+}
+
+/**
+ * Render inline content into a container that no React tree above it owns, for
+ * the reading-view and editor surfaces that build their DOM by hand.
+ *
+ * The render populates `container` before this returns, so the caller hands the
+ * container straight back to Obsidian. The root is then left alone: the
+ * component holds no effects to clean up, and the container dies with the DOM
+ * its surface inserted it into.
+ */
+export function renderInlineContent(
+  container: Element,
+  props: InlineContentProps,
+): void {
+  createRoot(container).render(<InlineContent {...props} />);
+}
+
+interface Context {
+  serials: readonly (number | undefined)[] | undefined;
+  links: "render" | "suppress";
+}
+
+/** The elements pandoc's own HTML writer gives these constructors. */
+const WRAPPER_TAGS = {
+  Emph: "em",
+  Strong: "strong",
+  Underline: "u",
+  Strikeout: "del",
+  Superscript: "sup",
+  Subscript: "sub",
+} as const;
+
+const QUOTE_MARKS = {
+  SingleQuote: ["‘", "’"],
+  DoubleQuote: ["“", "”"],
+} as const satisfies Record<QuoteType["t"], readonly [string, string]>;
+
+/**
+ * The spans citeproc lays an entry out with. They stand for a line break or a
+ * column in the style's own layout, which an inline flow has nowhere to put, so
+ * each hands its content over and leaves one space where it stood.
+ */
+const DISPLAY_CLASSES = new Set([
+  "csl-block",
+  "csl-indent",
+  "csl-left-margin",
+  "csl-right-inline",
+]);
+
+/**
+ * The schemes a formatted link is followed under — a DOI, a URL, or an address.
+ * A target under any other scheme carries no CSL semantic, and an active one
+ * (`javascript:` above all) never reaches the DOM.
+ */
+const LINK_SCHEMES = new Set(["http:", "https:", "mailto:"]);
+
+/** The slot of a cited work the bibliography rendered no entry for. */
+const NO_ENTRY = "⚠";
+
+/**
+ * Walk one flow into the nodes that show it.
+ *
+ * A constructor that stands for an element renders as that element; one that
+ * stands for a layout ({@link DISPLAY_CLASSES}, `Cite`, a link that stays
+ * behind) hands its own content to this same flow, so what it wrapped keeps
+ * reading as one run of text. A display span's boundary becomes a single space,
+ * whether or not the flow already carries one there.
+ */
+function renderFlow(nodes: Inlines, context: Context): ReactNode[] {
+  const flow: ReactNode[] = [];
+  /** Whether the flow already ends in a separator, so none is owed. */
+  let spaced = true;
+  /** Whether a display span just ended, so the next content starts a part. */
+  let boundary = false;
+  let key = 0;
+
+  function separate(): void {
+    if (spaced) return;
+    flow.push(" ");
+    spaced = true;
+  }
+
+  function add(node: ReactNode): void {
+    if (boundary) separate();
+    boundary = false;
+    flow.push(node);
+    spaced = false;
+  }
+
+  function walk(inlines: Inlines): void {
+    for (const inline of inlines) {
+      switch (inline.t) {
+        case "Str":
+          add(inline.c);
+          break;
+        case "Space":
+        case "SoftBreak":
+          separate();
+          break;
+        case "LineBreak":
+          add(<br key={key++} />);
+          break;
+        case "Emph":
+        case "Strong":
+        case "Underline":
+        case "Strikeout":
+        case "Superscript":
+        case "Subscript":
+          add(
+            createElement(
+              WRAPPER_TAGS[inline.t],
+              { key: key++ },
+              renderFlow(inline.c, context),
+            ),
+          );
+          break;
+        case "SmallCaps":
+          add(
+            <span key={key++} className="zt:[font-variant:small-caps]">
+              {renderFlow(inline.c, context)}
+            </span>,
+          );
+          break;
+        case "Quoted": {
+          const [open, close] = QUOTE_MARKS[inline.c[0].t];
+          add(open);
+          walk(inline.c[1]);
+          add(close);
+          break;
+        }
+        case "Code": {
+          const [, source] = inline.c;
+          add(<code key={key++}>{source}</code>);
+          break;
+        }
+        case "Math": {
+          const [, source] = inline.c;
+          add(source);
+          break;
+        }
+        case "Cite": {
+          const [, content] = inline.c;
+          walk(content);
+          break;
+        }
+        case "Image": {
+          const [, alt] = inline.c;
+          walk(alt);
+          break;
+        }
+        case "Span": {
+          const [[, classes], content] = inline.c;
+          const display = classes.some((name) => DISPLAY_CLASSES.has(name));
+          if (display) separate();
+          walk(content);
+          if (display) boundary = true;
+          break;
+        }
+        case "Link": {
+          const [, children, [url, title]] = inline.c;
+          const href = context.links === "render" ? linkHref(url) : null;
+          if (href === null) {
+            walk(children);
+            break;
+          }
+          add(
+            <a key={key++} href={href} aria-label={title || undefined}>
+              {renderFlow(children, context)}
+            </a>,
+          );
+          break;
+        }
+        case "Note": {
+          const { serials } = context;
+          if (!serials?.length) {
+            logger.debug("Dropped a note with no serial to stand for it", {
+              inline: inline.t,
+            });
+            break;
+          }
+          add(
+            <sup key={key++} className={themeHook.entrySerial}>
+              {serials.map((serial) => serial ?? NO_ENTRY).join(",")}
+            </sup>,
+          );
+          break;
+        }
+        case "RawInline":
+          logger.debug("Dropped an inline the renderer cannot show", {
+            inline: inline.t,
+            format: inline.c[0],
+          });
+          break;
+      }
+    }
+  }
+
+  walk(nodes);
+  return flow;
+}
+
+/**
+ * A target is absolute here or nowhere: a fragment or a relative path resolves
+ * against a document the surface has none of.
+ *
+ * @returns the target when it is followable, `null` otherwise.
+ */
+function linkHref(url: string): string | null {
+  const target = URL.parse(url);
+  return target && LINK_SCHEMES.has(target.protocol) ? url : null;
+}

--- a/apps/obsidian/src/services/pandoc/inline-content.tsx
+++ b/apps/obsidian/src/services/pandoc/inline-content.tsx
@@ -82,8 +82,12 @@ function contextOf({ serials, links = "render" }: InlineContentProps): Context {
   return { serials, links };
 }
 
-/** The elements pandoc's own HTML writer gives these constructors. */
-const WRAPPER_TAGS = {
+/**
+ * The elements pandoc's own HTML writer gives these constructors. The one
+ * vocabulary of the plugin: the clipboard serializer writes the same elements
+ * this shows, so a formatted entry reads the same wherever it lands.
+ */
+export const WRAPPER_TAGS = {
   Emph: "em",
   Strong: "strong",
   Underline: "u",
@@ -92,7 +96,8 @@ const WRAPPER_TAGS = {
   Subscript: "sub",
 } as const;
 
-const QUOTE_MARKS = {
+/** The characters a quotation reaches the reader as, by its own quote type. */
+export const QUOTE_MARKS = {
   SingleQuote: ["‘", "’"],
   DoubleQuote: ["“", "”"],
 } as const satisfies Record<QuoteType["t"], readonly [string, string]>;
@@ -102,7 +107,7 @@ const QUOTE_MARKS = {
  * column in the style's own layout, which an inline flow has nowhere to put, so
  * each hands its content over and leaves one space where it stood.
  */
-const DISPLAY_CLASSES = new Set([
+export const DISPLAY_CLASSES = new Set([
   "csl-block",
   "csl-indent",
   "csl-left-margin",
@@ -327,11 +332,12 @@ function textOf(node: ReactNode): string {
 
 /**
  * A target is absolute here or nowhere: a fragment or a relative path resolves
- * against a document the surface has none of.
+ * against a document the surface has none of, and a destination outside the
+ * vault has none of either.
  *
  * @returns the target when it is followable, `null` otherwise.
  */
-function linkHref(url: string): string | null {
+export function linkHref(url: string): string | null {
   const target = URL.parse(url);
   return target && LINK_SCHEMES.has(target.protocol) ? url : null;
 }

--- a/apps/obsidian/src/services/pandoc/inline-content.tsx
+++ b/apps/obsidian/src/services/pandoc/inline-content.tsx
@@ -83,9 +83,9 @@ function contextOf({ serials, links = "render" }: InlineContentProps): Context {
 }
 
 /**
- * The elements pandoc's own HTML writer gives these constructors. The one
- * vocabulary of the plugin: the clipboard serializer writes the same elements
- * this shows, so a formatted entry reads the same wherever it lands.
+ * The elements pandoc's own HTML writer gives these constructors. Every walk of
+ * a flow wraps these six under this one table — the clipboard serializer as
+ * much as the renderer — so a formatted entry reads the same wherever it lands.
  */
 export const WRAPPER_TAGS = {
   Emph: "em",
@@ -125,34 +125,56 @@ const LINK_SCHEMES = new Set(["http:", "https:", "mailto:"]);
 const NO_ENTRY = "⚠";
 
 /**
+ * Track the separators a flow being written owes, so every walk of a flow
+ * spaces its parts the one way.
+ *
+ * A flow reads as one run of text: the separators between two parts collapse
+ * into a single space, a leading one is dropped, and a part that starts after a
+ * display span is owed a space whether or not the flow already carries one
+ * there.
+ *
+ * @param append how one written node reaches the flow being built.
+ */
+export function flowWriter<T>(append: (node: T | string) => void) {
+  /** Whether the flow already ends in a separator, so none is owed. */
+  let spaced = true;
+  /** Whether a display span just ended, so the next content starts a part. */
+  let boundary = false;
+
+  const separate = (): void => {
+    if (spaced) return;
+    append(" ");
+    spaced = true;
+  };
+
+  const add = (node: T | string): void => {
+    if (boundary) separate();
+    boundary = false;
+    append(node);
+    spaced = false;
+  };
+
+  const endPart = (): void => {
+    boundary = true;
+  };
+
+  return { separate, add, endPart };
+}
+
+/**
  * Walk one flow into the nodes that show it.
  *
  * A constructor that stands for an element renders as that element; one that
  * stands for a layout ({@link DISPLAY_CLASSES}, `Cite`, a link that stays
  * behind) hands its own content to this same flow, so what it wrapped keeps
- * reading as one run of text. A display span's boundary becomes a single space,
- * whether or not the flow already carries one there.
+ * reading as one run of text.
  */
 function renderFlow(nodes: Inlines, context: Context): ReactNode[] {
   const flow: ReactNode[] = [];
-  /** Whether the flow already ends in a separator, so none is owed. */
-  let spaced = true;
-  /** Whether a display span just ended, so the next content starts a part. */
-  let boundary = false;
-  let key = 0;
-
-  function separate(): void {
-    if (spaced) return;
-    flow.push(" ");
-    spaced = true;
-  }
-
-  function add(node: ReactNode): void {
-    if (boundary) separate();
-    boundary = false;
+  const { separate, add, endPart } = flowWriter<ReactNode>((node) => {
     flow.push(node);
-    spaced = false;
-  }
+  });
+  let key = 0;
 
   function walk(inlines: Inlines): void {
     for (const inline of inlines) {
@@ -220,7 +242,7 @@ function renderFlow(nodes: Inlines, context: Context): ReactNode[] {
           const display = classes.some((name) => DISPLAY_CLASSES.has(name));
           if (display) separate();
           walk(content);
-          if (display) boundary = true;
+          if (display) endPart();
           break;
         }
         case "Link": {

--- a/apps/obsidian/src/services/pandoc/inline-content.tsx
+++ b/apps/obsidian/src/services/pandoc/inline-content.tsx
@@ -1,7 +1,7 @@
 // The one rendering of a formatted inline flow, shared by every surface that shows citations.
 
 import type { ReactNode } from "react";
-import { createElement } from "react";
+import { createElement, isValidElement } from "react";
 import { createRoot } from "react-dom/client";
 
 import { getLogger } from "@/lib/log";
@@ -24,7 +24,8 @@ export interface InlineContentProps {
   /**
    * Whether a link target reaches the DOM as an anchor. A surface that inserts
    * into an anchor of its own suppresses them, since nesting one anchor in
-   * another is invalid; the link's own content still shows.
+   * another is invalid; the link's own content still shows, as plain text the
+   * surrounding anchor carries.
    * @default "render"
    */
   links?: "render" | "suppress";
@@ -41,31 +42,31 @@ export interface InlineContentProps {
  * detached and never unmount it. Text reaches the DOM as text alone: nothing a
  * style or an item field carries is ever read as markup.
  */
-export function InlineContent({
-  nodes,
-  serials,
-  links = "render",
-}: InlineContentProps) {
-  return <>{renderFlow(nodes, { serials, links })}</>;
+export function InlineContent(props: InlineContentProps) {
+  return <>{renderFlow(props.nodes, contextOf(props))}</>;
 }
 
 /**
  * Render inline content into a container that no React tree above it owns, for
  * the reading-view and editor surfaces that build their DOM by hand.
  *
- * The render populates `container` before this returns, so the caller hands the
- * container straight back to Obsidian. That population is asserted rather than
- * assumed: a container still empty here means the render deferred its commit,
- * and every surface is handing Obsidian an element it never fills. The root is
- * then left alone: the component holds no effects to clean up, and the
- * container dies with the DOM its surface inserted it into.
+ * The adapter walks the flow {@link InlineContent} renders and hands React the
+ * commit alone, which populates `container` before this returns, so the caller
+ * hands the container straight back to Obsidian. That population is asserted
+ * rather than assumed: a container left empty where the flow had something to
+ * show means the render deferred its commit, and every surface is handing
+ * Obsidian an element it never fills. A flow that shows nothing — no nodes, or
+ * none the renderer keeps — leaves the container empty on its own and passes.
+ * The root is then left alone: the component holds no effects to clean up, and
+ * the container dies with the DOM its surface inserted it into.
  */
 export function renderInlineContent(
   container: Element,
   props: InlineContentProps,
 ): void {
-  createRoot(container).render(<InlineContent {...props} />);
-  if (container.hasChildNodes()) return;
+  const flow = renderFlow(props.nodes, contextOf(props));
+  createRoot(container).render(<>{flow}</>);
+  if (flow.length === 0 || container.hasChildNodes()) return;
   logger.error("Detached render left the container empty", {
     inlines: props.nodes.length,
   });
@@ -74,6 +75,11 @@ export function renderInlineContent(
 interface Context {
   serials: readonly (number | undefined)[] | undefined;
   links: "render" | "suppress";
+}
+
+/** The one reading of the props both rendering paths walk a flow under. */
+function contextOf({ serials, links = "render" }: InlineContentProps): Context {
+  return { serials, links };
 }
 
 /** The elements pandoc's own HTML writer gives these constructors. */
@@ -214,7 +220,11 @@ function renderFlow(nodes: Inlines, context: Context): ReactNode[] {
         }
         case "Link": {
           const [, children, [url, title]] = inline.c;
-          const href = context.links === "render" ? linkHref(url) : null;
+          if (context.links === "suppress") {
+            add(plainText(children, context));
+            break;
+          }
+          const href = linkHref(url);
           if (href === null) {
             walk(children);
             break;
@@ -253,6 +263,25 @@ function renderFlow(nodes: Inlines, context: Context): ReactNode[] {
 
   walk(nodes);
   return flow;
+}
+
+/**
+ * The text one flow reads as, with every element it would render left out —
+ * how a link shows its content where the surface suppresses anchors, since the
+ * anchor that surface inserts into carries the text as its own.
+ */
+function plainText(inlines: Inlines, context: Context): string {
+  return textOf(renderFlow(inlines, context));
+}
+
+/** The text a rendered node holds, gathered from the nodes it wraps. */
+function textOf(node: ReactNode): string {
+  if (typeof node === "string") return node;
+  if (Array.isArray(node)) return node.map(textOf).join("");
+  if (isValidElement(node)) {
+    return textOf((node.props as { children?: ReactNode }).children);
+  }
+  return "";
 }
 
 /**

--- a/apps/obsidian/src/services/pandoc/render-cache.test.ts
+++ b/apps/obsidian/src/services/pandoc/render-cache.test.ts
@@ -11,12 +11,15 @@ import { defaults } from "@/services/settings/schema";
 import type { Settings } from "@/services/settings/schema";
 import type { ZoteroPrefEvents } from "@/services/zotero-pref/service";
 
+import type { Inlines } from "./ast";
 import type {
+  AstBibliographyEntry,
   BibliographyEntry,
   BibliographyRequest,
   CitationEngine,
   CitationRequest,
   DocumentRequest,
+  RenderedCitation,
 } from "./engine";
 import { BibliographyRenderCache } from "./render-cache";
 import type { PandocEngineStatus } from "./service";
@@ -32,6 +35,8 @@ function item(id: string): CslItemData {
 class EngineStub implements CitationEngine {
   readonly requests: BibliographyRequest[] = [];
   readonly citationRequests: CitationRequest[] = [];
+  readonly astRequests: BibliographyRequest[] = [];
+  readonly astCitationRequests: CitationRequest[] = [];
   /** Set to make the next render fail, as an engine that refuses one does. */
   fails = false;
 
@@ -49,11 +54,38 @@ class EngineStub implements CitationEngine {
     );
   }
 
+  renderBibliographyAst(
+    request: BibliographyRequest,
+  ): Promise<readonly AstBibliographyEntry[]> {
+    this.astRequests.push(request);
+    if (this.fails) return Promise.reject(new Error("no"));
+    return Promise.resolve(
+      request.items.map(({ id }, index) => ({
+        id,
+        marker: inlines(String(index + 1)),
+        content: inlines(`entry for ${id}`),
+      })),
+    );
+  }
+
   renderCitations(request: CitationRequest): Promise<DocumentFragment[]> {
     this.citationRequests.push(request);
     if (this.fails) return Promise.reject(new Error("no"));
     return Promise.resolve(
       request.citations.map((source) => fragment(`cite for ${source}`)),
+    );
+  }
+
+  renderCitationsAst(
+    request: CitationRequest,
+  ): Promise<readonly RenderedCitation[]> {
+    this.astCitationRequests.push(request);
+    if (this.fails) return Promise.reject(new Error("no"));
+    return Promise.resolve(
+      request.citations.map((source) => ({
+        content: inlines(`cite for ${source}`),
+        citations: [],
+      })),
     );
   }
 
@@ -70,6 +102,10 @@ function fragment(text: string): DocumentFragment {
   const content = document.createDocumentFragment();
   content.append(text);
   return content;
+}
+
+function inlines(text: string): Inlines {
+  return [{ t: "Str", c: text }];
 }
 
 class PandocEngineStub {
@@ -482,5 +518,75 @@ describe("BibliographyRenderCache citations", () => {
     ).resolves.not.toBeNull();
 
     expect(engine.citationRequests).toHaveLength(2);
+  });
+});
+
+describe("BibliographyRenderCache typed AST", () => {
+  const items = [item("alpha"), item("zebra")];
+
+  it("hands two consumers of the same cited set the identical value", async () => {
+    const { cache, engine } = await makeHarness();
+
+    const first = await cache.renderAst(items);
+    const second = await cache.renderAst([item("alpha"), item("zebra")]);
+
+    expect(engine.astRequests).toHaveLength(1);
+    expect(first).toMatchObject({ kind: "rendered", hasEntryMarkers: true });
+    if (first.kind !== "rendered" || second.kind !== "rendered") {
+      throw new Error("bibliography render missing");
+    }
+    expect(first.entries).toBe(second.entries);
+  });
+
+  it("hands two consumers of the same document the identical value", async () => {
+    const { cache, engine } = await makeHarness();
+
+    const first = await cache.renderCitationsAst(["[@alpha]"], items);
+    const second = await cache.renderCitationsAst(["[@alpha]"], items);
+
+    expect(engine.astCitationRequests).toHaveLength(1);
+    expect(first).toBe(second);
+  });
+
+  it("drops the typed renders with every other render", async () => {
+    const { cache, engine, db, invalidations } = await makeHarness();
+
+    await cache.renderAst(items);
+    await cache.renderCitationsAst(["[@alpha]"], items);
+    db.changed();
+    await cache.renderAst(items);
+    await cache.renderCitationsAst(["[@alpha]"], items);
+
+    expect(invalidations).toHaveLength(1);
+    expect(engine.astRequests).toHaveLength(2);
+    expect(engine.astCitationRequests).toHaveLength(2);
+  });
+
+  it("formats nothing while no engine is installed", async () => {
+    const { cache, engine, pandocEngine } = await makeHarness();
+    pandocEngine.setStatus({ kind: "absent" });
+
+    await expect(cache.renderAst(items)).resolves.toEqual({
+      kind: "unavailable",
+      reason: "engine-absent",
+    });
+    await expect(
+      cache.renderCitationsAst(["[@alpha]"], items),
+    ).resolves.toBeNull();
+    expect(engine.astRequests).toHaveLength(0);
+    expect(engine.astCitationRequests).toHaveLength(0);
+  });
+
+  it("asks again after a render the engine refused", async () => {
+    const { cache, engine } = await makeHarness();
+
+    engine.fails = true;
+    await expect(cache.renderAst(items)).resolves.toEqual({ kind: "failed" });
+    engine.fails = false;
+    await expect(cache.renderAst(items)).resolves.toMatchObject({
+      kind: "rendered",
+    });
+
+    expect(engine.astRequests).toHaveLength(2);
   });
 });

--- a/apps/obsidian/src/services/pandoc/render-cache.test.ts
+++ b/apps/obsidian/src/services/pandoc/render-cache.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment happy-dom
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -13,7 +12,6 @@ import type { ZoteroPrefEvents } from "@/services/zotero-pref/service";
 
 import type { Inlines } from "./ast";
 import type {
-  AstBibliographyEntry,
   BibliographyEntry,
   BibliographyRequest,
   CitationEngine,
@@ -35,29 +33,13 @@ function item(id: string): CslItemData {
 class EngineStub implements CitationEngine {
   readonly requests: BibliographyRequest[] = [];
   readonly citationRequests: CitationRequest[] = [];
-  readonly astRequests: BibliographyRequest[] = [];
-  readonly astCitationRequests: CitationRequest[] = [];
   /** Set to make the next render fail, as an engine that refuses one does. */
   fails = false;
 
   renderBibliography(
     request: BibliographyRequest,
-  ): Promise<BibliographyEntry[]> {
+  ): Promise<readonly BibliographyEntry[]> {
     this.requests.push(request);
-    if (this.fails) return Promise.reject(new Error("no"));
-    return Promise.resolve(
-      request.items.map(({ id }, index) => ({
-        id,
-        marker: String(index + 1),
-        content: fragment(`entry for ${id}`),
-      })),
-    );
-  }
-
-  renderBibliographyAst(
-    request: BibliographyRequest,
-  ): Promise<readonly AstBibliographyEntry[]> {
-    this.astRequests.push(request);
     if (this.fails) return Promise.reject(new Error("no"));
     return Promise.resolve(
       request.items.map(({ id }, index) => ({
@@ -68,18 +50,10 @@ class EngineStub implements CitationEngine {
     );
   }
 
-  renderCitations(request: CitationRequest): Promise<DocumentFragment[]> {
-    this.citationRequests.push(request);
-    if (this.fails) return Promise.reject(new Error("no"));
-    return Promise.resolve(
-      request.citations.map((source) => fragment(`cite for ${source}`)),
-    );
-  }
-
-  renderCitationsAst(
+  renderCitations(
     request: CitationRequest,
   ): Promise<readonly RenderedCitation[]> {
-    this.astCitationRequests.push(request);
+    this.citationRequests.push(request);
     if (this.fails) return Promise.reject(new Error("no"));
     return Promise.resolve(
       request.citations.map((source) => ({
@@ -96,12 +70,6 @@ class EngineStub implements CitationEngine {
   [Symbol.asyncDispose](): Promise<void> {
     return Promise.resolve();
   }
-}
-
-function fragment(text: string): DocumentFragment {
-  const content = document.createDocumentFragment();
-  content.append(text);
-  return content;
 }
 
 function inlines(text: string): Inlines {
@@ -462,9 +430,9 @@ describe("BibliographyRenderCache citations", () => {
 
     expect(engine.citationRequests).toHaveLength(1);
     expect(first).toBe(second);
-    expect(first?.map((citation) => citation.textContent)).toEqual([
-      "cite for [@alpha]",
-      "cite for @alpha",
+    expect(first?.map((citation) => citation.content)).toEqual([
+      inlines("cite for [@alpha]"),
+      inlines("cite for @alpha"),
     ]);
   });
 
@@ -518,75 +486,5 @@ describe("BibliographyRenderCache citations", () => {
     ).resolves.not.toBeNull();
 
     expect(engine.citationRequests).toHaveLength(2);
-  });
-});
-
-describe("BibliographyRenderCache typed AST", () => {
-  const items = [item("alpha"), item("zebra")];
-
-  it("hands two consumers of the same cited set the identical value", async () => {
-    const { cache, engine } = await makeHarness();
-
-    const first = await cache.renderAst(items);
-    const second = await cache.renderAst([item("alpha"), item("zebra")]);
-
-    expect(engine.astRequests).toHaveLength(1);
-    expect(first).toMatchObject({ kind: "rendered", hasEntryMarkers: true });
-    if (first.kind !== "rendered" || second.kind !== "rendered") {
-      throw new Error("bibliography render missing");
-    }
-    expect(first.entries).toBe(second.entries);
-  });
-
-  it("hands two consumers of the same document the identical value", async () => {
-    const { cache, engine } = await makeHarness();
-
-    const first = await cache.renderCitationsAst(["[@alpha]"], items);
-    const second = await cache.renderCitationsAst(["[@alpha]"], items);
-
-    expect(engine.astCitationRequests).toHaveLength(1);
-    expect(first).toBe(second);
-  });
-
-  it("drops the typed renders with every other render", async () => {
-    const { cache, engine, db, invalidations } = await makeHarness();
-
-    await cache.renderAst(items);
-    await cache.renderCitationsAst(["[@alpha]"], items);
-    db.changed();
-    await cache.renderAst(items);
-    await cache.renderCitationsAst(["[@alpha]"], items);
-
-    expect(invalidations).toHaveLength(1);
-    expect(engine.astRequests).toHaveLength(2);
-    expect(engine.astCitationRequests).toHaveLength(2);
-  });
-
-  it("formats nothing while no engine is installed", async () => {
-    const { cache, engine, pandocEngine } = await makeHarness();
-    pandocEngine.setStatus({ kind: "absent" });
-
-    await expect(cache.renderAst(items)).resolves.toEqual({
-      kind: "unavailable",
-      reason: "engine-absent",
-    });
-    await expect(
-      cache.renderCitationsAst(["[@alpha]"], items),
-    ).resolves.toBeNull();
-    expect(engine.astRequests).toHaveLength(0);
-    expect(engine.astCitationRequests).toHaveLength(0);
-  });
-
-  it("asks again after a render the engine refused", async () => {
-    const { cache, engine } = await makeHarness();
-
-    engine.fails = true;
-    await expect(cache.renderAst(items)).resolves.toEqual({ kind: "failed" });
-    engine.fails = false;
-    await expect(cache.renderAst(items)).resolves.toMatchObject({
-      kind: "rendered",
-    });
-
-    expect(engine.astRequests).toHaveLength(2);
   });
 });

--- a/apps/obsidian/src/services/pandoc/render-cache.ts
+++ b/apps/obsidian/src/services/pandoc/render-cache.ts
@@ -11,11 +11,7 @@ import type { Settings } from "@/services/settings/schema";
 import type { SettingsService } from "@/services/settings/service";
 import type { ZoteroPrefService } from "@/services/zotero-pref/service";
 
-import type {
-  AstBibliographyEntry,
-  BibliographyEntry,
-  RenderedCitation,
-} from "./engine";
+import type { BibliographyEntry, RenderedCitation } from "./engine";
 import type { PandocEngineService } from "./service";
 import { StyleXmlCache, styleHasEntryMarkers } from "./styles";
 
@@ -50,14 +46,14 @@ export interface BibliographyRenderCacheOptions {
 }
 
 /** A completed bibliography and whether its style supplies Entry Markers. */
-export interface BibliographyRenderResult<Entry = BibliographyEntry> {
-  entries: readonly Entry[];
+export interface BibliographyRenderResult {
+  entries: readonly BibliographyEntry[];
   hasEntryMarkers: boolean;
 }
 
 /** What the References Sidebar needs to replace or preserve its current list. */
-export type BibliographyRenderOutcome<Entry = BibliographyEntry> =
-  | ({ kind: "rendered" } & BibliographyRenderResult<Entry>)
+export type BibliographyRenderOutcome =
+  | ({ kind: "rendered" } & BibliographyRenderResult)
   | { kind: "unavailable"; reason: "engine-absent" | "style-missing" }
   | { kind: "failed" };
 
@@ -93,13 +89,6 @@ export class BibliographyRenderCache extends Service<void> {
   >(HELD_RENDERS);
   /** In-text citation renders, held the same way and dropped by the same signals. */
   readonly #citations = new BoundedCache<
-    Promise<RenderAttempt<readonly DocumentFragment[]>>
-  >(HELD_RENDERS);
-  /** The same two renders as typed AST, held under their own keys. */
-  readonly #astRenders = new BoundedCache<
-    Promise<RenderAttempt<BibliographyRenderResult<AstBibliographyEntry>>>
-  >(HELD_RENDERS);
-  readonly #astCitations = new BoundedCache<
     Promise<RenderAttempt<readonly RenderedCitation[]>>
   >(HELD_RENDERS);
   /** `undefined` until the first settings snapshot names the selected style. */
@@ -121,10 +110,10 @@ export class BibliographyRenderCache extends Service<void> {
   /**
    * The whole bibliography of `items`, formatted in the Citation and References Style.
    *
-   * Entries come back in the style's own bibliography order, and the entry
-   * content is shared with every other consumer of the same render — a consumer
-   * clones it rather than inserting it, which is what the DOM-content helper
-   * already does.
+   * Entries come back in the style's own bibliography order, as typed AST. The
+   * rendered value is deeply immutable and shared: every consumer of one render
+   * gets the identical value, so a consumer holds it as long as it likes and
+   * compares renders by reference.
    *
    * @param items the cited works as CSL-JSON, in the order they are cited.
    * @returns the formatted bibliography, or the unavailable or failed state
@@ -159,17 +148,13 @@ export class BibliographyRenderCache extends Service<void> {
   }
 
   /**
-   * One document's in-text citations, formatted in the Citation and References Style.
+   * One document's in-text citations, formatted in the Citation and References Style,
+   * each paired with the works it names.
    *
    * A style that numbers counts citations across the whole document, so the
    * unit rendered — and the unit cached — is every citation the document
-   * writes, in document order. The formatted content is shared with every other
-   * consumer of the same render, so a consumer inserts a clone of it.
-   *
-   * Every in-text surface now reads {@link renderCitationsAst} instead, so this
-   * fragment path carries no consumer of its own. It stands until the HTML
-   * parse path behind it is deleted, which retires the engine's own fragment
-   * renderer and this method together.
+   * writes, in document order. The rendered value is shared under the same
+   * contract as {@link render}.
    *
    * @param citations each citation as the source writes it, in document order.
    * @param items the works those citations name, each `id` the key the source
@@ -180,67 +165,6 @@ export class BibliographyRenderCache extends Service<void> {
   async renderCitations(
     citations: readonly string[],
     items: readonly CslItemData[],
-  ): Promise<readonly DocumentFragment[] | null> {
-    await this.ready.catch(() => undefined);
-    if (this.#engine.getStatus().kind !== "installed") return null;
-    if (citations.length === 0) return [];
-
-    const styleId = this.#styleId ?? null;
-    const key = renderKey(styleId, items, citations);
-    const attempt = await this.#hold({
-      held: this.#citations,
-      key,
-      format: () => this.#runCitations(citations, items, styleId),
-      kind: "citations",
-    });
-    return attempt.kind === "rendered" ? attempt.value : null;
-  }
-
-  /**
-   * The same whole bibliography as {@link render}, as typed AST.
-   *
-   * The rendered value is deeply immutable and shared: every consumer of one
-   * render gets the identical value, so a consumer holds it as long as it likes
-   * and compares renders by reference.
-   */
-  async renderAst(
-    items: readonly CslItemData[],
-  ): Promise<BibliographyRenderOutcome<AstBibliographyEntry>> {
-    await this.ready.catch(() => undefined);
-    if (this.#engine.getStatus().kind !== "installed") {
-      return { kind: "unavailable", reason: "engine-absent" };
-    }
-    if (items.length === 0) {
-      return { kind: "rendered", entries: [], hasEntryMarkers: false };
-    }
-
-    const styleId = this.#styleId ?? null;
-    const attempt = await this.#hold({
-      held: this.#astRenders,
-      key: renderKey(styleId, items),
-      format: () => this.#runBibliographyAst(items, styleId),
-      kind: "bibliography",
-    });
-    switch (attempt.kind) {
-      case "rendered":
-        return { kind: "rendered", ...attempt.value };
-      case "style-missing":
-        return { kind: "unavailable", reason: "style-missing" };
-      case "failed":
-        return { kind: "failed" };
-    }
-  }
-
-  /**
-   * The same document's in-text citations as {@link renderCitations}, as typed
-   * AST, each paired with the works it names.
-   *
-   * @returns one rendered citation per source, in the same order; `null` when
-   *   the engine or selected style is unavailable, or the render failed.
-   */
-  async renderCitationsAst(
-    citations: readonly string[],
-    items: readonly CslItemData[],
   ): Promise<readonly RenderedCitation[] | null> {
     await this.ready.catch(() => undefined);
     if (this.#engine.getStatus().kind !== "installed") return null;
@@ -248,9 +172,9 @@ export class BibliographyRenderCache extends Service<void> {
 
     const styleId = this.#styleId ?? null;
     const attempt = await this.#hold({
-      held: this.#astCitations,
+      held: this.#citations,
       key: renderKey(styleId, items, citations),
-      format: () => this.#runCitationsAst(citations, items, styleId),
+      format: () => this.#runCitations(citations, items, styleId),
       kind: "citations",
     });
     return attempt.kind === "rendered" ? attempt.value : null;
@@ -320,12 +244,7 @@ export class BibliographyRenderCache extends Service<void> {
 
   /** @returns how many renders were held before they were dropped. */
   #clearHeld(): number {
-    const held = [
-      this.#renders,
-      this.#citations,
-      this.#astRenders,
-      this.#astCitations,
-    ];
+    const held = [this.#renders, this.#citations];
     const count = held.reduce((total, cache) => total + cache.size, 0);
     for (const cache of held) cache.clear();
     return count;
@@ -373,61 +292,9 @@ export class BibliographyRenderCache extends Service<void> {
         count: entries.length,
         hasEntryMarkers,
       });
-      return {
-        kind: "rendered",
-        value: { entries, hasEntryMarkers },
-      };
-    } catch (error) {
-      logger.warn("Cannot format the bibliography", { error });
-      return { kind: "failed" };
-    }
-  }
-
-  async #runBibliographyAst(
-    items: readonly CslItemData[],
-    styleId: string | null,
-  ): Promise<RenderAttempt<BibliographyRenderResult<AstBibliographyEntry>>> {
-    try {
-      const styleXml = await this.#resolveStyle(styleId);
-      if (styleXml.kind === "missing") return { kind: "style-missing" };
-      const xml = styleXml.kind === "installed" ? styleXml.xml : undefined;
-      const engine = await this.#engine.getEngine();
-      const entries = await engine.renderBibliographyAst({
-        items,
-        styleXml: xml,
-      });
-      const hasEntryMarkers =
-        styleHasEntryMarkers(xml) ||
-        entries.some((entry) => entry.marker !== undefined);
-      logger.debug("Bibliography rendered as AST", {
-        count: entries.length,
-        hasEntryMarkers,
-      });
       return { kind: "rendered", value: { entries, hasEntryMarkers } };
     } catch (error) {
       logger.warn("Cannot format the bibliography", { error });
-      return { kind: "failed" };
-    }
-  }
-
-  async #runCitationsAst(
-    citations: readonly string[],
-    items: readonly CslItemData[],
-    styleId: string | null,
-  ): Promise<RenderAttempt<readonly RenderedCitation[]>> {
-    try {
-      const styleXml = await this.#resolveStyle(styleId);
-      if (styleXml.kind === "missing") return { kind: "style-missing" };
-      const engine = await this.#engine.getEngine();
-      const rendered = await engine.renderCitationsAst({
-        citations,
-        items,
-        styleXml: styleXml.kind === "installed" ? styleXml.xml : undefined,
-      });
-      logger.debug("Citations rendered as AST", { count: rendered.length });
-      return { kind: "rendered", value: rendered };
-    } catch (error) {
-      logger.warn("Cannot format the citations", { error });
       return { kind: "failed" };
     }
   }
@@ -436,7 +303,7 @@ export class BibliographyRenderCache extends Service<void> {
     citations: readonly string[],
     items: readonly CslItemData[],
     styleId: string | null,
-  ): Promise<RenderAttempt<readonly DocumentFragment[]>> {
+  ): Promise<RenderAttempt<readonly RenderedCitation[]>> {
     try {
       const styleXml = await this.#resolveStyle(styleId);
       if (styleXml.kind === "missing") return { kind: "style-missing" };

--- a/apps/obsidian/src/services/pandoc/render-cache.ts
+++ b/apps/obsidian/src/services/pandoc/render-cache.ts
@@ -156,8 +156,8 @@ export class BibliographyRenderCache extends Service<void> {
    * consumer of the same render, so a consumer inserts a clone of it.
    *
    * @param citations each citation as the source writes it, in document order.
-   * @param items the works those citekeys resolve to, each `id` the citekey the
-   *   source writes.
+   * @param items the works those citations name, each `id` the key the source
+   *   names that work by.
    * @returns one formatted citation per source, in the same order; `null` when
    *   the engine or selected style is unavailable, or the render failed.
    */
@@ -335,9 +335,9 @@ export class BibliographyRenderCache extends Service<void> {
 /**
  * The identity of one render: the style that formats it, the works it covers in
  * the order they are cited, and — for an in-text render — the citations it
- * formats. A CSL id is a Zotero item URI or a citation key, so neither can
- * carry the separator, and the empty line between the two lists keeps them
- * apart.
+ * formats. A CSL id names one Item — a Zotero item URI, an Indexed Key, or a
+ * citation key — and none of the three can carry the separator, so the empty
+ * line between the two lists keeps them apart.
  */
 function renderKey(
   styleId: string | null,

--- a/apps/obsidian/src/services/pandoc/render-cache.ts
+++ b/apps/obsidian/src/services/pandoc/render-cache.ts
@@ -166,6 +166,11 @@ export class BibliographyRenderCache extends Service<void> {
    * writes, in document order. The formatted content is shared with every other
    * consumer of the same render, so a consumer inserts a clone of it.
    *
+   * Every in-text surface now reads {@link renderCitationsAst} instead, so this
+   * fragment path carries no consumer of its own. It stands until the HTML
+   * parse path behind it is deleted, which retires the engine's own fragment
+   * renderer and this method together.
+   *
    * @param citations each citation as the source writes it, in document order.
    * @param items the works those citations name, each `id` the key the source
    *   names that work by.

--- a/apps/obsidian/src/services/pandoc/render-cache.ts
+++ b/apps/obsidian/src/services/pandoc/render-cache.ts
@@ -11,7 +11,11 @@ import type { Settings } from "@/services/settings/schema";
 import type { SettingsService } from "@/services/settings/service";
 import type { ZoteroPrefService } from "@/services/zotero-pref/service";
 
-import type { BibliographyEntry } from "./engine";
+import type {
+  AstBibliographyEntry,
+  BibliographyEntry,
+  RenderedCitation,
+} from "./engine";
 import type { PandocEngineService } from "./service";
 import { StyleXmlCache, styleHasEntryMarkers } from "./styles";
 
@@ -46,14 +50,14 @@ export interface BibliographyRenderCacheOptions {
 }
 
 /** A completed bibliography and whether its style supplies Entry Markers. */
-export interface BibliographyRenderResult {
-  entries: readonly BibliographyEntry[];
+export interface BibliographyRenderResult<Entry = BibliographyEntry> {
+  entries: readonly Entry[];
   hasEntryMarkers: boolean;
 }
 
 /** What the References Sidebar needs to replace or preserve its current list. */
-export type BibliographyRenderOutcome =
-  | ({ kind: "rendered" } & BibliographyRenderResult)
+export type BibliographyRenderOutcome<Entry = BibliographyEntry> =
+  | ({ kind: "rendered" } & BibliographyRenderResult<Entry>)
   | { kind: "unavailable"; reason: "engine-absent" | "style-missing" }
   | { kind: "failed" };
 
@@ -90,6 +94,13 @@ export class BibliographyRenderCache extends Service<void> {
   /** In-text citation renders, held the same way and dropped by the same signals. */
   readonly #citations = new BoundedCache<
     Promise<RenderAttempt<readonly DocumentFragment[]>>
+  >(HELD_RENDERS);
+  /** The same two renders as typed AST, held under their own keys. */
+  readonly #astRenders = new BoundedCache<
+    Promise<RenderAttempt<BibliographyRenderResult<AstBibliographyEntry>>>
+  >(HELD_RENDERS);
+  readonly #astCitations = new BoundedCache<
+    Promise<RenderAttempt<readonly RenderedCitation[]>>
   >(HELD_RENDERS);
   /** `undefined` until the first settings snapshot names the selected style. */
   #styleId: string | null | undefined;
@@ -180,6 +191,66 @@ export class BibliographyRenderCache extends Service<void> {
     return attempt.kind === "rendered" ? attempt.value : null;
   }
 
+  /**
+   * The same whole bibliography as {@link render}, as typed AST.
+   *
+   * The rendered value is deeply immutable and shared: every consumer of one
+   * render gets the identical value, so a consumer holds it as long as it likes
+   * and compares renders by reference.
+   */
+  async renderAst(
+    items: readonly CslItemData[],
+  ): Promise<BibliographyRenderOutcome<AstBibliographyEntry>> {
+    await this.ready.catch(() => undefined);
+    if (this.#engine.getStatus().kind !== "installed") {
+      return { kind: "unavailable", reason: "engine-absent" };
+    }
+    if (items.length === 0) {
+      return { kind: "rendered", entries: [], hasEntryMarkers: false };
+    }
+
+    const styleId = this.#styleId ?? null;
+    const attempt = await this.#hold({
+      held: this.#astRenders,
+      key: renderKey(styleId, items),
+      format: () => this.#runBibliographyAst(items, styleId),
+      kind: "bibliography",
+    });
+    switch (attempt.kind) {
+      case "rendered":
+        return { kind: "rendered", ...attempt.value };
+      case "style-missing":
+        return { kind: "unavailable", reason: "style-missing" };
+      case "failed":
+        return { kind: "failed" };
+    }
+  }
+
+  /**
+   * The same document's in-text citations as {@link renderCitations}, as typed
+   * AST, each paired with the works it names.
+   *
+   * @returns one rendered citation per source, in the same order; `null` when
+   *   the engine or selected style is unavailable, or the render failed.
+   */
+  async renderCitationsAst(
+    citations: readonly string[],
+    items: readonly CslItemData[],
+  ): Promise<readonly RenderedCitation[] | null> {
+    await this.ready.catch(() => undefined);
+    if (this.#engine.getStatus().kind !== "installed") return null;
+    if (citations.length === 0) return [];
+
+    const styleId = this.#styleId ?? null;
+    const attempt = await this.#hold({
+      held: this.#astCitations,
+      key: renderKey(styleId, items, citations),
+      format: () => this.#runCitationsAst(citations, items, styleId),
+      kind: "citations",
+    });
+    return attempt.kind === "rendered" ? attempt.value : null;
+  }
+
   on<K extends keyof BibliographyRenderEvents>(
     event: K,
     cb: BibliographyRenderEvents[K],
@@ -211,8 +282,7 @@ export class BibliographyRenderCache extends Service<void> {
       }),
     );
     stack.defer(() => {
-      this.#renders.clear();
-      this.#citations.clear();
+      this.#clearHeld();
     });
 
     this.commit(stack.move());
@@ -238,11 +308,22 @@ export class BibliographyRenderCache extends Service<void> {
    */
   #invalidate(): void {
     logger.debug("Dropped the bibliography renders", {
-      count: this.#renders.size + this.#citations.size,
+      count: this.#clearHeld(),
     });
-    this.#renders.clear();
-    this.#citations.clear();
     this.#emitter.emit("invalidated");
+  }
+
+  /** @returns how many renders were held before they were dropped. */
+  #clearHeld(): number {
+    const held = [
+      this.#renders,
+      this.#citations,
+      this.#astRenders,
+      this.#astCitations,
+    ];
+    const count = held.reduce((total, cache) => total + cache.size, 0);
+    for (const cache of held) cache.clear();
+    return count;
   }
 
   /** Answer `key` from `held`, running `format` when nothing holds it yet. */
@@ -293,6 +374,55 @@ export class BibliographyRenderCache extends Service<void> {
       };
     } catch (error) {
       logger.warn("Cannot format the bibliography", { error });
+      return { kind: "failed" };
+    }
+  }
+
+  async #runBibliographyAst(
+    items: readonly CslItemData[],
+    styleId: string | null,
+  ): Promise<RenderAttempt<BibliographyRenderResult<AstBibliographyEntry>>> {
+    try {
+      const styleXml = await this.#resolveStyle(styleId);
+      if (styleXml.kind === "missing") return { kind: "style-missing" };
+      const xml = styleXml.kind === "installed" ? styleXml.xml : undefined;
+      const engine = await this.#engine.getEngine();
+      const entries = await engine.renderBibliographyAst({
+        items,
+        styleXml: xml,
+      });
+      const hasEntryMarkers =
+        styleHasEntryMarkers(xml) ||
+        entries.some((entry) => entry.marker !== undefined);
+      logger.debug("Bibliography rendered as AST", {
+        count: entries.length,
+        hasEntryMarkers,
+      });
+      return { kind: "rendered", value: { entries, hasEntryMarkers } };
+    } catch (error) {
+      logger.warn("Cannot format the bibliography", { error });
+      return { kind: "failed" };
+    }
+  }
+
+  async #runCitationsAst(
+    citations: readonly string[],
+    items: readonly CslItemData[],
+    styleId: string | null,
+  ): Promise<RenderAttempt<readonly RenderedCitation[]>> {
+    try {
+      const styleXml = await this.#resolveStyle(styleId);
+      if (styleXml.kind === "missing") return { kind: "style-missing" };
+      const engine = await this.#engine.getEngine();
+      const rendered = await engine.renderCitationsAst({
+        citations,
+        items,
+        styleXml: styleXml.kind === "installed" ? styleXml.xml : undefined,
+      });
+      logger.debug("Citations rendered as AST", { count: rendered.length });
+      return { kind: "rendered", value: rendered };
+    } catch (error) {
+      logger.warn("Cannot format the citations", { error });
       return { kind: "failed" };
     }
   }

--- a/apps/obsidian/src/services/pandoc/service.test.ts
+++ b/apps/obsidian/src/services/pandoc/service.test.ts
@@ -76,9 +76,7 @@ function memoryConsent(): MemoryConsent {
 function fakeEngine(dispose = vi.fn()): CitationEngine {
   return {
     renderBibliography: () => Promise.resolve([]),
-    renderBibliographyAst: () => Promise.resolve([]),
     renderCitations: () => Promise.resolve([]),
-    renderCitationsAst: () => Promise.resolve([]),
     renderDocument: () => Promise.resolve(new Uint8Array()),
     [Symbol.asyncDispose]: () => {
       dispose();

--- a/apps/obsidian/src/services/pandoc/service.test.ts
+++ b/apps/obsidian/src/services/pandoc/service.test.ts
@@ -76,7 +76,9 @@ function memoryConsent(): MemoryConsent {
 function fakeEngine(dispose = vi.fn()): CitationEngine {
   return {
     renderBibliography: () => Promise.resolve([]),
+    renderBibliographyAst: () => Promise.resolve([]),
     renderCitations: () => Promise.resolve([]),
+    renderCitationsAst: () => Promise.resolve([]),
     renderDocument: () => Promise.resolve(new Uint8Array()),
     [Symbol.asyncDispose]: () => {
       dispose();

--- a/apps/obsidian/src/services/wikilink-editor/decorate.test.ts
+++ b/apps/obsidian/src/services/wikilink-editor/decorate.test.ts
@@ -85,6 +85,7 @@ describe("wikilinkDecorations", () => {
         citation: {
           source: "[@wang2020, p. 7]",
           keys: [{ citekey: "wang2020", start: 1, end: 10 }],
+          works: [WANG.indexedKey],
         },
         tokenClasses: ["hmd-internal-link"],
       },

--- a/apps/obsidian/src/services/wikilink-editor/decorate.test.ts
+++ b/apps/obsidian/src/services/wikilink-editor/decorate.test.ts
@@ -87,6 +87,9 @@ describe("wikilinkDecorations", () => {
           keys: [{ citekey: "wang2020", start: 1, end: 10 }],
           works: [WANG.indexedKey],
         },
+        // The `[[` the document writes the Citation at, which the shared text
+        // keys its occurrence by.
+        start: 0,
         tokenClasses: ["hmd-internal-link"],
       },
     ]);

--- a/apps/obsidian/src/services/wikilink-editor/decorate.ts
+++ b/apps/obsidian/src/services/wikilink-editor/decorate.ts
@@ -2,7 +2,6 @@
 // scanned links form a Citation, over which range, and with which reconstructed
 // token classes.
 
-import type { CitationSource } from "@/lib/citation-fragment";
 import { overlapsSelection } from "@/lib/editor-decoration";
 import type { DocRange } from "@/lib/editor-decoration";
 import {
@@ -10,7 +9,10 @@ import {
   citationRuns,
   wikilinkCitation,
 } from "@/lib/wikilink-citation";
-import type { WikilinkCitationContext } from "@/lib/wikilink-citation";
+import type {
+  RunCitationSource,
+  WikilinkCitationContext,
+} from "@/lib/wikilink-citation";
 
 import type { WikilinkSpan } from "./scan";
 
@@ -39,8 +41,8 @@ export interface WikilinkDisplayContext extends WikilinkCitationContext {
 
 /** One Citation to replace, with everything its widget needs. */
 export interface WikilinkDecoration extends DocRange {
-  /** The Pandoc source of the Citation, which a formatted render is keyed by. */
-  citation: CitationSource;
+  /** The Pandoc source of the Citation and the works it names, which a formatted render is keyed by. */
+  citation: RunCitationSource;
   /** {@link WikilinkSpan.tokenClasses} */
   tokenClasses: readonly string[];
 }

--- a/apps/obsidian/src/services/wikilink-editor/decorate.ts
+++ b/apps/obsidian/src/services/wikilink-editor/decorate.ts
@@ -43,6 +43,12 @@ export interface WikilinkDisplayContext extends WikilinkCitationContext {
 export interface WikilinkDecoration extends DocRange {
   /** The Pandoc source of the Citation and the works it names, which a formatted render is keyed by. */
   citation: RunCitationSource;
+  /**
+   * Document offset the Citation starts at — its first `[[`, the offset
+   * Obsidian's own link cache reports — which picks out its occurrence.
+   * {@link DocRange.from} is the narrower inner range the widget replaces.
+   */
+  start: number;
   /** {@link WikilinkSpan.tokenClasses} */
   tokenClasses: readonly string[];
 }
@@ -84,6 +90,7 @@ export function wikilinkDecorations(
       from: first.inner.from,
       to: last.inner.to,
       citation,
+      start: first.outer.from,
       tokenClasses: first.tokenClasses,
     });
   }

--- a/apps/obsidian/src/services/wikilink-editor/extension.ts
+++ b/apps/obsidian/src/services/wikilink-editor/extension.ts
@@ -19,8 +19,10 @@ import {
   citationContent,
   showCitation,
 } from "@/services/citation-text/present";
-import type { DocumentCitations } from "@/services/citation-text/present";
-import type { RenderedCitation } from "@/services/pandoc/engine";
+import type {
+  DocumentCitations,
+  PresentedCitation,
+} from "@/services/citation-text/present";
 
 import { wikilinkDecorations } from "./decorate";
 import type { WikilinkDecoration } from "./decorate";
@@ -157,7 +159,7 @@ class CitationDisplayWidget extends WidgetType {
   readonly #content;
   readonly #className;
 
-  constructor(content: RenderedCitation, tokenClasses: readonly string[]) {
+  constructor(content: PresentedCitation, tokenClasses: readonly string[]) {
     super();
     this.#content = content;
     this.#className = [

--- a/apps/obsidian/src/services/wikilink-editor/extension.ts
+++ b/apps/obsidian/src/services/wikilink-editor/extension.ts
@@ -248,7 +248,10 @@ function replacement(
   decoration: WikilinkDecoration,
   citations: DocumentCitations,
 ): Decoration | null {
-  const formatted = citationContent(decoration.citation, citations);
+  const formatted = citationContent(decoration.citation, citations, {
+    kind: "offset",
+    start: decoration.start,
+  });
   if (formatted === null) return null;
   return Decoration.replace({
     widget: new CitationDisplayWidget(formatted, decoration.tokenClasses),

--- a/apps/obsidian/src/services/wikilink-editor/extension.ts
+++ b/apps/obsidian/src/services/wikilink-editor/extension.ts
@@ -17,9 +17,10 @@ import { themeHook } from "@/lib/theme-hooks";
 import type { LiteratureNoteTarget } from "@/lib/wikilink-citation";
 import {
   citationContent,
-  citationInsert,
+  showCitation,
 } from "@/services/citation-text/present";
 import type { DocumentCitations } from "@/services/citation-text/present";
+import type { RenderedCitation } from "@/services/pandoc/engine";
 
 import { wikilinkDecorations } from "./decorate";
 import type { WikilinkDecoration } from "./decorate";
@@ -156,10 +157,7 @@ class CitationDisplayWidget extends WidgetType {
   readonly #content;
   readonly #className;
 
-  constructor(
-    content: DocumentFragment | string,
-    tokenClasses: readonly string[],
-  ) {
+  constructor(content: RenderedCitation, tokenClasses: readonly string[]) {
     super();
     this.#content = content;
     this.#className = [
@@ -171,8 +169,9 @@ class CitationDisplayWidget extends WidgetType {
   }
 
   /**
-   * Formatted content is the very object the document's held citations carry,
-   * so a fresh read of that document is a fresh object and redraws.
+   * Formatted content is the immutable value the document's held citations
+   * carry, so the comparison is a reference test and a fresh read of that
+   * document is a fresh value that redraws.
    */
   eq(other: CitationDisplayWidget): boolean {
     return (
@@ -185,7 +184,10 @@ class CitationDisplayWidget extends WidgetType {
     element.className = this.#className;
     element.tabIndex = -1;
     element.draggable = true;
-    element.append(citationInsert(this.#content));
+    // The widget stands for a link Obsidian's own handlers navigate, so a link
+    // the style wrote shows as the text it carries rather than as an anchor
+    // that would take the gesture away from them.
+    showCitation(element, this.#content, "suppress");
     return element;
   }
 }

--- a/apps/obsidian/src/services/wikilink-editor/theme-hooks.test.ts
+++ b/apps/obsidian/src/services/wikilink-editor/theme-hooks.test.ts
@@ -76,7 +76,9 @@ vi.mock("obsidian", async (importOriginal) => {
 
 import { editorInfoField } from "obsidian";
 
+import { rendered } from "@/services/citation-text/__fixtures__";
 import { citationKey } from "@/services/citation-text/present";
+import type { RenderedCitation } from "@/services/pandoc/engine";
 
 import { wikilinkEditorExtension } from "./extension";
 
@@ -91,7 +93,13 @@ function viewOf(
   {
     enabled = true,
     formatted = true,
-  }: { enabled?: boolean; formatted?: boolean } = {},
+    content = rendered("(Example 2020, p. 7)"),
+  }: {
+    enabled?: boolean;
+    formatted?: boolean;
+    /** The formatted citation the shared text holds for the document. */
+    content?: RenderedCitation;
+  } = {},
 ) {
   const view = new EditorView({
     parent: document.body,
@@ -105,8 +113,6 @@ function viewOf(
           enabled: () => enabled,
           citationText: () => {
             if (!formatted) return null;
-            const citation = document.createDocumentFragment();
-            citation.append("(Example 2020, p. 7)");
             return {
               formatted: new Map([
                 [
@@ -114,7 +120,7 @@ function viewOf(
                     source: "[@example, p. 7]",
                     works: [LITERATURE_NOTE.indexedKey],
                   }),
-                  citation,
+                  content,
                 ],
               ]),
               summaries: new Map([
@@ -162,5 +168,30 @@ describe("wikilinkEditorExtension theme hooks", () => {
 
       expect(view.dom.querySelector(".zt-literature-note-link")).toBeNull();
     }
+  });
+});
+
+describe("wikilinkEditorExtension citation rendering", () => {
+  it("shows a link the style wrote as text, since the widget is the link", () => {
+    livePreview.mockReturnValue(true);
+    using view = viewOf("[[literatures/example#cite:locator=7]]", {
+      content: {
+        content: [
+          {
+            t: "Link",
+            c: [
+              ["", [], []],
+              [{ t: "Str", c: "doi.org/10.1/x" }],
+              ["https://doi.org/10.1/x", ""],
+            ],
+          },
+        ],
+        citations: [],
+      },
+    });
+
+    const citation = view.dom.querySelector(".zt-citation");
+    expect(citation?.querySelector("a")).toBeNull();
+    expect(citation?.textContent).toBe("doi.org/10.1/x");
   });
 });

--- a/apps/obsidian/src/services/wikilink-editor/theme-hooks.test.ts
+++ b/apps/obsidian/src/services/wikilink-editor/theme-hooks.test.ts
@@ -76,6 +76,8 @@ vi.mock("obsidian", async (importOriginal) => {
 
 import { editorInfoField } from "obsidian";
 
+import { citationKey } from "@/services/citation-text/present";
+
 import { wikilinkEditorExtension } from "./extension";
 
 const LITERATURE_NOTE = {
@@ -106,8 +108,19 @@ function viewOf(
             const citation = document.createDocumentFragment();
             citation.append("(Example 2020, p. 7)");
             return {
-              formatted: new Map([["[@example, p. 7]", citation]]),
-              summaries: new Map([["example", "Example (2020)"]]),
+              formatted: new Map([
+                [
+                  citationKey({
+                    source: "[@example, p. 7]",
+                    works: [LITERATURE_NOTE.indexedKey],
+                  }),
+                  citation,
+                ],
+              ]),
+              summaries: new Map([
+                [LITERATURE_NOTE.indexedKey, "Example (2020)"],
+              ]),
+              literalWorks: new Map(),
             };
           },
           requestCitationText: () => undefined,

--- a/apps/obsidian/src/services/wikilink-editor/theme-hooks.test.ts
+++ b/apps/obsidian/src/services/wikilink-editor/theme-hooks.test.ts
@@ -76,7 +76,7 @@ vi.mock("obsidian", async (importOriginal) => {
 
 import { editorInfoField } from "obsidian";
 
-import { rendered } from "@/services/citation-text/__fixtures__";
+import { occurrence, rendered } from "@/services/citation-text/__fixtures__";
 import { citationKey } from "@/services/citation-text/present";
 import type { RenderedCitation } from "@/services/pandoc/engine";
 
@@ -120,7 +120,7 @@ function viewOf(
                     source: "[@example, p. 7]",
                     works: [LITERATURE_NOTE.indexedKey],
                   }),
-                  content,
+                  occurrence(content),
                 ],
               ]),
               summaries: new Map([

--- a/apps/obsidian/src/services/wikilink-editor/theme-hooks.test.ts
+++ b/apps/obsidian/src/services/wikilink-editor/theme-hooks.test.ts
@@ -76,7 +76,7 @@ vi.mock("obsidian", async (importOriginal) => {
 
 import { editorInfoField } from "obsidian";
 
-import { occurrence, rendered } from "@/services/citation-text/__fixtures__";
+import { occurrences, rendered } from "@/services/citation-text/__fixtures__";
 import { citationKey } from "@/services/citation-text/present";
 import type { RenderedCitation } from "@/services/pandoc/engine";
 
@@ -120,7 +120,7 @@ function viewOf(
                     source: "[@example, p. 7]",
                     works: [LITERATURE_NOTE.indexedKey],
                   }),
-                  occurrence(content),
+                  occurrences(content),
                 ],
               ]),
               summaries: new Map([

--- a/apps/obsidian/src/services/wikilink-editor/theme-hooks.test.ts
+++ b/apps/obsidian/src/services/wikilink-editor/theme-hooks.test.ts
@@ -78,6 +78,7 @@ import { editorInfoField } from "obsidian";
 
 import { occurrences, rendered } from "@/services/citation-text/__fixtures__";
 import { citationKey } from "@/services/citation-text/present";
+import type { DocumentCitations } from "@/services/citation-text/present";
 import type { RenderedCitation } from "@/services/pandoc/engine";
 
 import { wikilinkEditorExtension } from "./extension";
@@ -101,6 +102,22 @@ function viewOf(
     content?: RenderedCitation;
   } = {},
 ) {
+  // Held once, the way the service holds one document's answer: every ask
+  // gets the same value, which is what lets a widget compare by reference.
+  const held: DocumentCitations = {
+    entrySerials: false,
+    formatted: new Map([
+      [
+        citationKey({
+          source: "[@example, p. 7]",
+          works: [LITERATURE_NOTE.indexedKey],
+        }),
+        occurrences(content),
+      ],
+    ]),
+    summaries: new Map([[LITERATURE_NOTE.indexedKey, "Example (2020)"]]),
+    literalWorks: new Map(),
+  };
   const view = new EditorView({
     parent: document.body,
     state: EditorState.create({
@@ -111,24 +128,7 @@ function viewOf(
           literatureNote: (linkpath) =>
             linkpath === "literatures/example" ? LITERATURE_NOTE : null,
           enabled: () => enabled,
-          citationText: () => {
-            if (!formatted) return null;
-            return {
-              formatted: new Map([
-                [
-                  citationKey({
-                    source: "[@example, p. 7]",
-                    works: [LITERATURE_NOTE.indexedKey],
-                  }),
-                  occurrences(content),
-                ],
-              ]),
-              summaries: new Map([
-                [LITERATURE_NOTE.indexedKey, "Example (2020)"],
-              ]),
-              literalWorks: new Map(),
-            };
-          },
+          citationText: () => (formatted ? held : null),
           requestCitationText: () => undefined,
         }),
       ],

--- a/apps/obsidian/src/services/wikilink-editor/theme-hooks.test.ts
+++ b/apps/obsidian/src/services/wikilink-editor/theme-hooks.test.ts
@@ -194,4 +194,19 @@ describe("wikilinkEditorExtension citation rendering", () => {
     expect(citation?.querySelector("a")).toBeNull();
     expect(citation?.textContent).toBe("doi.org/10.1/x");
   });
+
+  it("keeps the drawn citation while an edit lands away from it", () => {
+    livePreview.mockReturnValue(true);
+    using view = viewOf("[[literatures/example#cite:locator=7]] tail");
+    const drawn = view.dom.querySelector(".zt-citation");
+    expect(drawn?.textContent).toBe("(Example 2020, p. 7)");
+
+    view.dispatch({
+      changes: { from: view.state.doc.length, insert: " more" },
+    });
+
+    // The held text is one shared value, so the widget compares equal by
+    // reference and CodeMirror keeps the element it already drew.
+    expect(view.dom.querySelector(".zt-citation")).toBe(drawn);
+  });
 });

--- a/apps/obsidian/src/services/wikilink-reading/render.test.ts
+++ b/apps/obsidian/src/services/wikilink-reading/render.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, it } from "vitest";
 
 import { citationOfRun, wikilinkCitation } from "@/lib/wikilink-citation";
 import type { RunMember, WikilinkCitation } from "@/lib/wikilink-citation";
-import { rendered } from "@/services/citation-text/__fixtures__";
-import type { RenderedCitation } from "@/services/pandoc/engine";
+import { presented } from "@/services/citation-text/__fixtures__";
+import type { PresentedCitation } from "@/services/citation-text/present";
 
 import { internalLink, section } from "./__fixtures__/internal-link";
 import { renderCitationRuns, sectionCitationRuns } from "./render";
@@ -15,7 +15,7 @@ const renderWikilinkCitations = (
   citations: (linktext: string) => WikilinkCitation | null,
   format: (
     run: readonly RunMember<HTMLAnchorElement>[],
-  ) => RenderedCitation | null,
+  ) => PresentedCitation | null,
 ): number => renderCitationRuns(sectionCitationRuns(root, citations), format);
 
 /** Every `literatures/…` link names a Literature Note; nothing else does. */
@@ -35,10 +35,10 @@ const citationOf = (linktext: string): WikilinkCitation | null =>
 /** Stand-in formatted text used to exercise the generic DOM swap. */
 const display = (
   run: readonly RunMember<HTMLAnchorElement>[],
-): RenderedCitation => {
+): PresentedCitation => {
   const only = run.length === 1 ? run[0]!.citation.item : null;
   const details = only?.details;
-  return rendered(
+  return presented(
     only &&
       details?.mode === "normal" &&
       details.prefix === null &&
@@ -71,14 +71,17 @@ describe("renderWikilinkCitations", () => {
   it("puts the formatted citation, markup and all, in the anchor", () => {
     const root = section(`<p>${internalLink("literatures/wang2020")}</p>`);
     renderWikilinkCitations(root, citationOf, () => ({
-      content: [
-        { t: "Str", c: "(Wang" },
-        { t: "Space" },
-        { t: "Emph", c: [{ t: "Str", c: "et al." }] },
-        { t: "Space" },
-        { t: "Str", c: "2020)" },
-      ],
-      citations: [],
+      text: {
+        content: [
+          { t: "Str", c: "(Wang" },
+          { t: "Space" },
+          { t: "Emph", c: [{ t: "Str", c: "et al." }] },
+          { t: "Space" },
+          { t: "Str", c: "2020)" },
+        ],
+        citations: [],
+      },
+      serials: [],
     }));
 
     expect(root.querySelector("a")?.innerHTML).toBe(
@@ -89,17 +92,20 @@ describe("renderWikilinkCitations", () => {
   it("shows a link the style wrote as text, since the anchor is Obsidian's", () => {
     const root = section(`<p>${internalLink("literatures/wang2020")}</p>`);
     renderWikilinkCitations(root, citationOf, () => ({
-      content: [
-        {
-          t: "Link",
-          c: [
-            ["", [], []],
-            [{ t: "Str", c: "doi.org/10.1/x" }],
-            ["https://doi.org/10.1/x", ""],
-          ],
-        },
-      ],
-      citations: [],
+      text: {
+        content: [
+          {
+            t: "Link",
+            c: [
+              ["", [], []],
+              [{ t: "Str", c: "doi.org/10.1/x" }],
+              ["https://doi.org/10.1/x", ""],
+            ],
+          },
+        ],
+        citations: [],
+      },
+      serials: [],
     }));
 
     const anchor = root.querySelector("a");
@@ -173,8 +179,8 @@ describe("renderWikilinkCitations over a Citation Run", () => {
   /** The formatted text of a run, which names the works it groups. */
   const grouped = (
     run: readonly RunMember<HTMLAnchorElement>[],
-  ): RenderedCitation =>
-    rendered(
+  ): PresentedCitation =>
+    presented(
       `(${run.map(({ citation }) => citation.item.citekey).join("; ")})`,
     );
 

--- a/apps/obsidian/src/services/wikilink-reading/render.test.ts
+++ b/apps/obsidian/src/services/wikilink-reading/render.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 
 import { citationOfRun, wikilinkCitation } from "@/lib/wikilink-citation";
 import type { RunMember, WikilinkCitation } from "@/lib/wikilink-citation";
+import { rendered } from "@/services/citation-text/__fixtures__";
+import type { RenderedCitation } from "@/services/pandoc/engine";
 
 import { internalLink, section } from "./__fixtures__/internal-link";
 import { renderCitationRuns, sectionCitationRuns } from "./render";
@@ -13,7 +15,7 @@ const renderWikilinkCitations = (
   citations: (linktext: string) => WikilinkCitation | null,
   format: (
     run: readonly RunMember<HTMLAnchorElement>[],
-  ) => Node | string | null,
+  ) => RenderedCitation | null,
 ): number => renderCitationRuns(sectionCitationRuns(root, citations), format);
 
 /** Every `literatures/…` link names a Literature Note; nothing else does. */
@@ -31,16 +33,20 @@ const citationOf = (linktext: string): WikilinkCitation | null =>
   });
 
 /** Stand-in formatted text used to exercise the generic DOM swap. */
-const display = (run: readonly RunMember<HTMLAnchorElement>[]): string => {
+const display = (
+  run: readonly RunMember<HTMLAnchorElement>[],
+): RenderedCitation => {
   const only = run.length === 1 ? run[0]!.citation.item : null;
   const details = only?.details;
-  return only &&
-    details?.mode === "normal" &&
-    details.prefix === null &&
-    details.locator === null &&
-    details.suffix === null
-    ? `@${only.citekey}`
-    : citationOfRun(run).source;
+  return rendered(
+    only &&
+      details?.mode === "normal" &&
+      details.prefix === null &&
+      details.locator === null &&
+      details.suffix === null
+      ? `@${only.citekey}`
+      : citationOfRun(run).source,
+  );
 };
 
 describe("renderWikilinkCitations", () => {
@@ -62,14 +68,43 @@ describe("renderWikilinkCitations", () => {
     expect(root.textContent).toBe("[@wang2020, p. 7]");
   });
 
-  it("puts a formatted citation in the anchor", () => {
+  it("puts the formatted citation, markup and all, in the anchor", () => {
     const root = section(`<p>${internalLink("literatures/wang2020")}</p>`);
-    const formatted = document.createElement("span");
-    formatted.textContent = "(Wang et al. 2020)";
-    renderWikilinkCitations(root, citationOf, () => formatted);
+    renderWikilinkCitations(root, citationOf, () => ({
+      content: [
+        { t: "Str", c: "(Wang" },
+        { t: "Space" },
+        { t: "Emph", c: [{ t: "Str", c: "et al." }] },
+        { t: "Space" },
+        { t: "Str", c: "2020)" },
+      ],
+      citations: [],
+    }));
 
-    expect(root.querySelector("a")?.firstElementChild).toBe(formatted);
-    expect(root.textContent).toBe("(Wang et al. 2020)");
+    expect(root.querySelector("a")?.innerHTML).toBe(
+      "(Wang <em>et al.</em> 2020)",
+    );
+  });
+
+  it("shows a link the style wrote as text, since the anchor is Obsidian's", () => {
+    const root = section(`<p>${internalLink("literatures/wang2020")}</p>`);
+    renderWikilinkCitations(root, citationOf, () => ({
+      content: [
+        {
+          t: "Link",
+          c: [
+            ["", [], []],
+            [{ t: "Str", c: "doi.org/10.1/x" }],
+            ["https://doi.org/10.1/x", ""],
+          ],
+        },
+      ],
+      citations: [],
+    }));
+
+    const anchor = root.querySelector("a");
+    expect(anchor?.querySelector("a")).toBeNull();
+    expect(anchor?.textContent).toBe("doi.org/10.1/x");
   });
 
   it("keeps the target and every native attribute", () => {
@@ -136,8 +171,12 @@ describe("renderWikilinkCitations", () => {
 
 describe("renderWikilinkCitations over a Citation Run", () => {
   /** The formatted text of a run, which names the works it groups. */
-  const grouped = (run: readonly RunMember<HTMLAnchorElement>[]): string =>
-    `(${run.map(({ citation }) => citation.item.citekey).join("; ")})`;
+  const grouped = (
+    run: readonly RunMember<HTMLAnchorElement>[],
+  ): RenderedCitation =>
+    rendered(
+      `(${run.map(({ citation }) => citation.item.citekey).join("; ")})`,
+    );
 
   it("collapses a semicolon-joined run into its first anchor", () => {
     const root = section(

--- a/apps/obsidian/src/services/wikilink-reading/render.ts
+++ b/apps/obsidian/src/services/wikilink-reading/render.ts
@@ -48,9 +48,13 @@ export type WikilinkCitationOf = (linktext: string) => WikilinkCitation | null;
 /**
  * The formatted text one Citation Run shows in place of its links, or null to
  * leave them as Obsidian rendered them.
+ *
+ * `index` is the run's place in the section's own document order, which is what
+ * tells two identical Citations of one section apart.
  */
 export type FormatWikilinkRun = (
   run: readonly RunMember<HTMLAnchorElement>[],
+  index: number,
 ) => RenderedCitation | null;
 
 /** The Citation Runs of one rendered section, as their anchors carry them. */
@@ -102,8 +106,8 @@ export function renderCitationRuns(
   format: FormatWikilinkRun,
 ): number {
   let rendered = 0;
-  for (const run of runs) {
-    const content = format(run);
+  for (const [index, run] of runs.entries()) {
+    const content = format(run, index);
     if (content === null) continue;
     const first = run[0]!.source;
     // Everything between the run's anchors is the separators that joined them,

--- a/apps/obsidian/src/services/wikilink-reading/render.ts
+++ b/apps/obsidian/src/services/wikilink-reading/render.ts
@@ -4,6 +4,8 @@
 import { themeHook } from "@/lib/theme-hooks";
 import { citationRuns } from "@/lib/wikilink-citation";
 import type { RunMember, WikilinkCitation } from "@/lib/wikilink-citation";
+import { showCitation } from "@/services/citation-text/present";
+import type { RenderedCitation } from "@/services/pandoc/engine";
 
 /**
  * Obsidian's own anchor for an internal link, which its Markdown parser builds
@@ -44,12 +46,12 @@ function breadcrumb(linktext: string): string {
 export type WikilinkCitationOf = (linktext: string) => WikilinkCitation | null;
 
 /**
- * What one Citation Run shows in place of its links, or null to leave them as
- * Obsidian rendered them.
+ * The formatted text one Citation Run shows in place of its links, or null to
+ * leave them as Obsidian rendered them.
  */
 export type FormatWikilinkRun = (
   run: readonly RunMember<HTMLAnchorElement>[],
-) => Node | string | null;
+) => RenderedCitation | null;
 
 /** The Citation Runs of one rendered section, as their anchors carry them. */
 export type SectionRuns = RunMember<HTMLAnchorElement>[][];
@@ -89,6 +91,10 @@ export function sectionCitationRuns(
  * run widget makes, and the one place a run departs from #663's per-link
  * interaction. A lone Citation keeps its anchor and every gesture on it.
  *
+ * The formatted text goes into Obsidian's own anchor, so a link the style wrote
+ * shows as the text it carries: an anchor inside an anchor is invalid, and the
+ * one this surface writes into already navigates to the Literature Note.
+ *
  * @returns how many Citations show their formatted text.
  */
 export function renderCitationRuns(
@@ -106,7 +112,7 @@ export function renderCitationRuns(
       removeBetween(first, source);
       source.remove();
     }
-    first.replaceChildren(content);
+    showCitation(first, content, "suppress");
     first.classList.add(themeHook.citation, themeHook.literatureNoteLink);
     rendered += 1;
   }

--- a/apps/obsidian/src/services/wikilink-reading/render.ts
+++ b/apps/obsidian/src/services/wikilink-reading/render.ts
@@ -5,7 +5,7 @@ import { themeHook } from "@/lib/theme-hooks";
 import { citationRuns } from "@/lib/wikilink-citation";
 import type { RunMember, WikilinkCitation } from "@/lib/wikilink-citation";
 import { showCitation } from "@/services/citation-text/present";
-import type { RenderedCitation } from "@/services/pandoc/engine";
+import type { PresentedCitation } from "@/services/citation-text/present";
 
 /**
  * Obsidian's own anchor for an internal link, which its Markdown parser builds
@@ -55,7 +55,7 @@ export type WikilinkCitationOf = (linktext: string) => WikilinkCitation | null;
 export type FormatWikilinkRun = (
   run: readonly RunMember<HTMLAnchorElement>[],
   index: number,
-) => RenderedCitation | null;
+) => PresentedCitation | null;
 
 /** The Citation Runs of one rendered section, as their anchors carry them. */
 export type SectionRuns = RunMember<HTMLAnchorElement>[][];

--- a/apps/obsidian/src/services/wikilink-reading/service.test.ts
+++ b/apps/obsidian/src/services/wikilink-reading/service.test.ts
@@ -3,6 +3,7 @@ import { MarkdownView } from "obsidian";
 import type { MarkdownPostProcessor } from "obsidian";
 import { describe, expect, it } from "vitest";
 
+import { citationKey } from "@/services/citation-text/present";
 import { defaults } from "@/services/settings/schema";
 import type { Settings } from "@/services/settings/schema";
 
@@ -11,6 +12,13 @@ import { WikilinkReading } from "./service";
 
 /** The one Literature Note the metadata-cache stand-in knows. */
 const WANG = "literatures/wangMutationalClinicalSpectrum2020a";
+/** The Indexed Key that note carries, which the shared text holds its Citations under. */
+const WANG_KEY = "ABCD2345";
+
+/** One Citation as the shared text holds it: its Pandoc source, and the works it names. */
+function held(source: string, works: string[] = [WANG_KEY]): string {
+  return citationKey({ source, works });
+}
 
 interface Harness extends AsyncDisposable {
   settings: SettingsStub;
@@ -38,7 +46,7 @@ async function harness({
   pending,
   ...overrides
 }: Partial<Settings> & {
-  /** The formatted citation the shared text holds, by its Pandoc source. */
+  /** The formatted citation the shared text holds, by its {@link held} identity. */
   formatted?: Record<string, string>;
   /** Keep the citation-text read pending. */
   pending?: boolean;
@@ -51,7 +59,7 @@ async function harness({
   const noteIndex = new NoteIndexStub();
   const citationText = new CitationTextStub(formatted ?? {}, pending);
   const citationIndex = new CitationIndexStub(
-    citekeys ?? { ABCD2345: "wang2020" },
+    citekeys ?? { [WANG_KEY]: "wang2020" },
   );
   let rerenders = 0;
   let process: MarkdownPostProcessor | undefined;
@@ -68,7 +76,7 @@ async function harness({
             ? { path: `${WANG}.md` }
             : null,
         getFileCache: () => ({
-          frontmatter: { "zotero-key": "ABCD2345" },
+          frontmatter: { "zotero-key": WANG_KEY },
         }),
       },
     },
@@ -164,7 +172,7 @@ describe("WikilinkReading rendering", () => {
   it("exposes both literal hooks when it renders a Literature Note Citation", async () => {
     await using harnessed = await harness({
       "citation.wikilink-citations": true,
-      formatted: { "[@wang2020, p. 7]": "(Wang et al. 2020, p. 7)" },
+      formatted: { [held("[@wang2020, p. 7]")]: "(Wang et al. 2020, p. 7)" },
     });
 
     const root = await harnessed.renderSection(`${WANG}#cite:locator=7`);
@@ -178,7 +186,8 @@ describe("WikilinkReading rendering", () => {
     await using harnessed = await harness({
       "citation.wikilink-citations": true,
       formatted: {
-        "[@wang2020, p. 7; @wang2020, p. 9]": "(Wang et al. 2020, pp. 7, 9)",
+        [held("[@wang2020, p. 7; @wang2020, p. 9]", [WANG_KEY, WANG_KEY])]:
+          "(Wang et al. 2020, pp. 7, 9)",
       },
     });
     const root = await harnessed.renderHtml(
@@ -241,7 +250,7 @@ describe("WikilinkReading rendering", () => {
   it("shows the citation a style formatted once the shared text holds one", async () => {
     await using harnessed = await harness({
       "citation.wikilink-citations": true,
-      formatted: { "[@wang2020, p. 7]": "(Wang et al. 2020, p. 7)" },
+      formatted: { [held("[@wang2020, p. 7]")]: "(Wang et al. 2020, p. 7)" },
     });
 
     expect(await harnessed.render(`${WANG}#cite:locator=7`)).toBe(
@@ -253,7 +262,7 @@ describe("WikilinkReading rendering", () => {
     await using harnessed = await harness({
       "citation.wikilink-citations": true,
       "citation.show-formatted": false,
-      formatted: { "[@wang2020, p. 7]": "(Wang et al. 2020, p. 7)" },
+      formatted: { [held("[@wang2020, p. 7]")]: "(Wang et al. 2020, p. 7)" },
     });
 
     const root = await harnessed.renderSection(`${WANG}#cite:locator=7`);

--- a/apps/obsidian/src/services/wikilink-reading/service.test.ts
+++ b/apps/obsidian/src/services/wikilink-reading/service.test.ts
@@ -3,9 +3,9 @@ import { MarkdownView } from "obsidian";
 import type { MarkdownPostProcessor } from "obsidian";
 import { describe, expect, it } from "vitest";
 
-import { rendered } from "@/services/citation-text/__fixtures__";
+import { occurrence, rendered } from "@/services/citation-text/__fixtures__";
 import { citationKey } from "@/services/citation-text/present";
-import type { RenderedCitation } from "@/services/pandoc/engine";
+import type { FormattedOccurrence } from "@/services/citation-text/present";
 import { defaults } from "@/services/settings/schema";
 import type { Settings } from "@/services/settings/schema";
 
@@ -65,6 +65,9 @@ async function harness({
   );
   let rerenders = 0;
   let process: MarkdownPostProcessor | undefined;
+  // Obsidian places a section of this stubbed document nowhere, which is the
+  // degraded tier: every Citation shows its source's first-occurrence text.
+  const ctx = { sourcePath, getSectionInfo: () => null } as never;
   const view = Object.assign(Object.create(MarkdownView.prototype) as object, {
     previewMode: { rerender: () => rerenders++ },
   });
@@ -100,24 +103,24 @@ async function harness({
     citationIndex,
     render: async (linktext) => {
       const root = section(`<p>${internalLink(linktext)}</p>`);
-      await process?.(root, { sourcePath } as never);
+      await process?.(root, ctx);
       return root.textContent ?? "";
     },
     renderSection: async (linktext, alias) => {
       const root = section(`<p>${internalLink(linktext, alias)}</p>`);
-      await process?.(root, { sourcePath } as never);
+      await process?.(root, ctx);
       return root;
     },
     renderHtml: async (html) => {
       const root = section(html);
-      await process?.(root, { sourcePath } as never);
+      await process?.(root, ctx);
       return root;
     },
     beginRender: (linktext) => {
       const root = section(`<p>${internalLink(linktext)}</p>`);
       return {
         root,
-        completion: Promise.resolve(process?.(root, { sourcePath } as never)),
+        completion: Promise.resolve(process?.(root, ctx)),
       };
     },
     rerenders: () => rerenders,
@@ -373,7 +376,7 @@ describe("WikilinkReading rerender", () => {
 
 /** What the stub holds for one document, as a surface reads it. */
 interface HeldText {
-  formatted: Map<string, RenderedCitation>;
+  formatted: Map<string, FormattedOccurrence[]>;
   summaries: Map<string, string>;
 }
 
@@ -400,9 +403,9 @@ class CitationTextStub {
   }
 
   #text(): HeldText {
-    const formatted = new Map<string, RenderedCitation>();
+    const formatted = new Map<string, FormattedOccurrence[]>();
     for (const [source, text] of Object.entries(this.#formatted)) {
-      formatted.set(source, rendered(text));
+      formatted.set(source, occurrence(rendered(text)));
     }
     return { formatted, summaries: new Map() };
   }

--- a/apps/obsidian/src/services/wikilink-reading/service.test.ts
+++ b/apps/obsidian/src/services/wikilink-reading/service.test.ts
@@ -3,7 +3,9 @@ import { MarkdownView } from "obsidian";
 import type { MarkdownPostProcessor } from "obsidian";
 import { describe, expect, it } from "vitest";
 
+import { rendered } from "@/services/citation-text/__fixtures__";
 import { citationKey } from "@/services/citation-text/present";
+import type { RenderedCitation } from "@/services/pandoc/engine";
 import { defaults } from "@/services/settings/schema";
 import type { Settings } from "@/services/settings/schema";
 
@@ -369,6 +371,12 @@ describe("WikilinkReading rerender", () => {
   });
 });
 
+/** What the stub holds for one document, as a surface reads it. */
+interface HeldText {
+  formatted: Map<string, RenderedCitation>;
+  summaries: Map<string, string>;
+}
+
 class CitationTextStub {
   readonly #formatted: Record<string, string>;
   readonly #pending: boolean;
@@ -382,30 +390,19 @@ class CitationTextStub {
     this.#pending = pending;
   }
 
-  load(): Promise<{
-    formatted: Map<string, DocumentFragment>;
-    summaries: Map<string, string>;
-  }> {
+  load(): Promise<HeldText> {
     if (this.#pending) return new Promise(() => undefined);
     return Promise.resolve(this.#text());
   }
 
-  peek(): {
-    formatted: Map<string, DocumentFragment>;
-    summaries: Map<string, string>;
-  } | null {
+  peek(): HeldText | null {
     return this.#pending ? null : this.#text();
   }
 
-  #text(): {
-    formatted: Map<string, DocumentFragment>;
-    summaries: Map<string, string>;
-  } {
-    const formatted = new Map<string, DocumentFragment>();
+  #text(): HeldText {
+    const formatted = new Map<string, RenderedCitation>();
     for (const [source, text] of Object.entries(this.#formatted)) {
-      const content = document.createDocumentFragment();
-      content.append(text);
-      formatted.set(source, content);
+      formatted.set(source, rendered(text));
     }
     return { formatted, summaries: new Map() };
   }

--- a/apps/obsidian/src/services/wikilink-reading/service.test.ts
+++ b/apps/obsidian/src/services/wikilink-reading/service.test.ts
@@ -3,7 +3,7 @@ import { MarkdownView } from "obsidian";
 import type { MarkdownPostProcessor } from "obsidian";
 import { describe, expect, it } from "vitest";
 
-import { occurrence, rendered } from "@/services/citation-text/__fixtures__";
+import { occurrences, rendered } from "@/services/citation-text/__fixtures__";
 import { citationKey } from "@/services/citation-text/present";
 import type { FormattedOccurrence } from "@/services/citation-text/present";
 import { defaults } from "@/services/settings/schema";
@@ -405,7 +405,7 @@ class CitationTextStub {
   #text(): HeldText {
     const formatted = new Map<string, FormattedOccurrence[]>();
     for (const [source, text] of Object.entries(this.#formatted)) {
-      formatted.set(source, occurrence(rendered(text)));
+      formatted.set(source, occurrences(rendered(text)));
     }
     return { formatted, summaries: new Map() };
   }

--- a/apps/obsidian/src/services/wikilink-reading/service.ts
+++ b/apps/obsidian/src/services/wikilink-reading/service.ts
@@ -13,10 +13,7 @@ import {
   wikilinkCitation,
 } from "@/lib/wikilink-citation";
 import type { CitationIndex } from "@/services/citation-index/service";
-import {
-  citationContent,
-  citationInsert,
-} from "@/services/citation-text/present";
+import { citationContent } from "@/services/citation-text/present";
 import type { CitationText } from "@/services/citation-text/service";
 import { resolveLiteratureNote } from "@/services/note-index/service";
 import type { NoteIndex } from "@/services/note-index/service";
@@ -144,8 +141,7 @@ export class WikilinkReading extends Service<void> {
 
     const shown = renderCitationRuns(runs, (run) => {
       const citation = citationOfRun(run);
-      const formatted = text === null ? null : citationContent(citation, text);
-      return formatted === null ? null : citationInsert(formatted);
+      return text === null ? null : citationContent(citation, text);
     });
     if (shown > 0) {
       logger.trace("Rendered wikilink citations", {

--- a/apps/obsidian/src/services/wikilink-reading/service.ts
+++ b/apps/obsidian/src/services/wikilink-reading/service.ts
@@ -6,14 +6,17 @@
 import type { App, MarkdownPostProcessorContext, Plugin } from "obsidian";
 
 import { getLogger } from "@/lib/log";
-import { rerenderReadingViews } from "@/lib/reading-view";
+import { rerenderReadingViews, sectionRange } from "@/lib/reading-view";
 import {
   WikilinkDisplaySettings,
   citationOfRun,
   wikilinkCitation,
 } from "@/lib/wikilink-citation";
 import type { CitationIndex } from "@/services/citation-index/service";
-import { citationContent } from "@/services/citation-text/present";
+import {
+  citationContent,
+  sectionCoordinates,
+} from "@/services/citation-text/present";
 import type { CitationText } from "@/services/citation-text/service";
 import { resolveLiteratureNote } from "@/services/note-index/service";
 import type { NoteIndex } from "@/services/note-index/service";
@@ -139,10 +142,15 @@ export class WikilinkReading extends Service<void> {
     }
     if (this.#retired) return;
 
-    const shown = renderCitationRuns(runs, (run) => {
-      const citation = citationOfRun(run);
-      return text === null ? null : citationContent(citation, text);
-    });
+    // Which occurrence each Citation of the section is, so a position-dependent
+    // style shows every one of them the text rendered for its own place.
+    const citations = runs.map((run) => citationOfRun(run));
+    const coordinates = sectionCoordinates(citations, sectionRange(ctx, el));
+    const shown = renderCitationRuns(runs, (_run, index) =>
+      text === null
+        ? null
+        : citationContent(citations[index]!, text, coordinates[index]),
+    );
     if (shown > 0) {
       logger.trace("Rendered wikilink citations", {
         path: ctx.sourcePath,

--- a/apps/obsidian/src/views/references/References.test.ts
+++ b/apps/obsidian/src/views/references/References.test.ts
@@ -129,7 +129,7 @@ describe("References", () => {
           citekey: "aVeryLongCitekeyWithoutBreaks00000000000000000003",
         },
       ],
-      { kind: "bibliography", hasEntryMarkers: false },
+      { kind: "bibliography", hasEntryMarkers: false, entrySerials: false },
     );
 
     const list = container.querySelector("ul")!;
@@ -155,6 +155,7 @@ describe("References", () => {
           kind: "rendered",
           source,
           linkpath: "notes/BOOK0001",
+          serial: 1,
           marker: [{ t: "Str", c: "[1]" }],
           content: [
             { t: "Str", c: "Rendered" },
@@ -171,7 +172,7 @@ describe("References", () => {
           linkpath: "notes/BOOK0002",
         },
       ],
-      { kind: "bibliography", hasEntryMarkers: true },
+      { kind: "bibliography", hasEntryMarkers: true, entrySerials: false },
     );
 
     const rows = container.querySelectorAll("li");
@@ -198,6 +199,7 @@ describe("References", () => {
           kind: "rendered",
           source,
           linkpath: "notes/BOOK0001",
+          serial: 1,
           marker: undefined,
           content: [
             {
@@ -221,7 +223,7 @@ describe("References", () => {
           ],
         },
       ],
-      { kind: "bibliography", hasEntryMarkers: false },
+      { kind: "bibliography", hasEntryMarkers: false, entrySerials: false },
     );
 
     const row = container.querySelector("li")!;
@@ -244,13 +246,83 @@ describe("References", () => {
           linkpath: "notes/BOOK0001",
         },
       ],
-      { kind: "bibliography", hasEntryMarkers: true },
+      { kind: "bibliography", hasEntryMarkers: true, entrySerials: false },
     );
 
     expect(container.querySelector("ul")!.classList).toContain(
       "zt:grid-cols-[max-content_minmax(0,1fr)_max-content]",
     );
     expect(container.querySelector("li")!.children[0]!.textContent).toBe("⚠");
+  });
+
+  // A note-class style writes no Entry Marker, so the gutter carries the Entry
+  // Serials the document's own citations show.
+  it("shows Entry Serials in the gutter of a document that shows them", async () => {
+    const container = await render(
+      [
+        {
+          id: "BOOK0001",
+          refNumber: 2,
+          occurrences: [occurrence],
+          kind: "rendered",
+          source,
+          linkpath: "notes/BOOK0001",
+          serial: 1,
+          marker: undefined,
+          content: [{ t: "Str", c: "Zeta." }],
+        },
+        {
+          id: "BOOK0002",
+          refNumber: 1,
+          occurrences: [occurrence],
+          kind: "rendered",
+          source,
+          linkpath: "notes/BOOK0002",
+          serial: 2,
+          marker: undefined,
+          content: [{ t: "Str", c: "Rivers." }],
+        },
+        {
+          id: "GONE0003",
+          refNumber: 3,
+          occurrences: [occurrence],
+          kind: "missing",
+          linkpath: "notes/GONE0003",
+        },
+      ],
+      { kind: "bibliography", hasEntryMarkers: false, entrySerials: true },
+    );
+
+    const rows = container.querySelectorAll("li");
+    expect(container.querySelector("ul")!.classList).toContain(
+      "zt:grid-cols-[max-content_minmax(0,1fr)_max-content]",
+    );
+    expect([...rows].map((row) => row.children[0]!.textContent)).toEqual([
+      "1",
+      "2",
+      "⚠",
+    ]);
+  });
+
+  it("keeps the Entry Marker in the gutter of a style that writes one", async () => {
+    const container = await render(
+      [
+        {
+          id: "BOOK0001",
+          refNumber: 1,
+          occurrences: [occurrence],
+          kind: "rendered",
+          source,
+          linkpath: "notes/BOOK0001",
+          serial: 1,
+          marker: [{ t: "Str", c: "[7]" }],
+          content: [{ t: "Str", c: "Zeta." }],
+        },
+      ],
+      { kind: "bibliography", hasEntryMarkers: true, entrySerials: true },
+    );
+
+    expect(container.querySelector("li")!.children[0]!.textContent).toBe("[7]");
   });
 
   it("uses Reference Numbers and warnings in the minimal list", async () => {
@@ -505,6 +577,7 @@ describe("References copy action", () => {
     kind: "rendered",
     source,
     linkpath: "notes/BOOK0001",
+    serial: 1,
     marker: [{ t: "Str", c: "[1]" }],
     content: [{ t: "Str", c: "Book" }],
   };
@@ -520,7 +593,7 @@ describe("References copy action", () => {
   async function ready(): Promise<HTMLElement> {
     return render(
       [renderedEntry],
-      { kind: "bibliography", hasEntryMarkers: true },
+      { kind: "bibliography", hasEntryMarkers: true, entrySerials: false },
       { copy: { kind: "ready", target } },
     );
   }
@@ -562,7 +635,7 @@ describe("References copy action", () => {
     async (reason, tooltip) => {
       const container = await render(
         [renderedEntry],
-        { kind: "bibliography", hasEntryMarkers: true },
+        { kind: "bibliography", hasEntryMarkers: true, entrySerials: false },
         { copy: { kind: "blocked", reason } },
       );
       const action = copyAction(container);

--- a/apps/obsidian/src/views/references/References.test.ts
+++ b/apps/obsidian/src/views/references/References.test.ts
@@ -146,8 +146,6 @@ describe("References", () => {
   });
 
   it("shares a numeric style's gutter with an unrendered Reference Error", async () => {
-    const content = document.createDocumentFragment();
-    content.append("Rendered book");
     const container = await render(
       [
         {
@@ -157,8 +155,12 @@ describe("References", () => {
           kind: "rendered",
           source,
           linkpath: "notes/BOOK0001",
-          marker: "[1]",
-          content,
+          marker: [{ t: "Str", c: "[1]" }],
+          content: [
+            { t: "Str", c: "Rendered" },
+            { t: "Space" },
+            { t: "Str", c: "book" },
+          ],
         },
         {
           id: "BOOK0002",
@@ -184,6 +186,50 @@ describe("References", () => {
         el.getAttribute("data-icon"),
       ),
     ).toStrictEqual(["file-text", "external-link", "chevron-right"]);
+  });
+
+  it("shows the markup and the links a formatted entry carries", async () => {
+    const container = await render(
+      [
+        {
+          id: "BOOK0001",
+          refNumber: 1,
+          occurrences: [occurrence],
+          kind: "rendered",
+          source,
+          linkpath: "notes/BOOK0001",
+          marker: undefined,
+          content: [
+            {
+              t: "Emph",
+              c: [
+                { t: "Str", c: "Field" },
+                { t: "Space" },
+                { t: "Str", c: "notes" },
+              ],
+            },
+            { t: "Str", c: "." },
+            { t: "Space" },
+            {
+              t: "Link",
+              c: [
+                ["", [], []],
+                [{ t: "Str", c: "https://doi.org/10.1000/182" }],
+                ["https://doi.org/10.1000/182", ""],
+              ],
+            },
+          ],
+        },
+      ],
+      { kind: "bibliography", hasEntryMarkers: false },
+    );
+
+    const row = container.querySelector("li")!;
+    expect(row.querySelector("em")?.textContent).toBe("Field notes");
+    // A bare anchor, which Obsidian itself opens in the system browser.
+    const link = row.querySelector("a")!;
+    expect(link.getAttribute("href")).toBe("https://doi.org/10.1000/182");
+    expect(link.getAttributeNames()).toStrictEqual(["href"]);
   });
 
   it("keeps a numeric style's gutter when every Item was omitted", async () => {
@@ -459,8 +505,8 @@ describe("References copy action", () => {
     kind: "rendered",
     source,
     linkpath: "notes/BOOK0001",
-    marker: "[1]",
-    content: document.createDocumentFragment(),
+    marker: [{ t: "Str", c: "[1]" }],
+    content: [{ t: "Str", c: "Book" }],
   };
 
   function copyAction(container: HTMLElement): HTMLElement {

--- a/apps/obsidian/src/views/references/References.tsx
+++ b/apps/obsidian/src/views/references/References.tsx
@@ -5,9 +5,9 @@ import { Button } from "@/components/obsidian/button";
 import { IconButton } from "@/components/obsidian/icon-button";
 import { SidebarToolbar } from "@/components/sidebar-toolbar";
 import * as m from "@/lib/i18n/generated/messages";
-import { useDomContent } from "@/lib/sanitize-html";
 import { cn, tooltipAttrs } from "@/lib/utils";
 import type { ReferenceSource } from "@/services/citation-index/service";
+import { InlineContent } from "@/services/pandoc/inline-content";
 import type {
   PandocEngineFailure,
   PandocEngineStatus,
@@ -280,7 +280,7 @@ function referencePresentation(
   entry: ReferenceEntry,
   numbered: boolean,
 ): {
-  gutter: string | number | undefined;
+  gutter: ReactNode;
   warning: boolean;
   noteLabel: string;
   noteDisabled: boolean;
@@ -289,7 +289,11 @@ function referencePresentation(
   switch (entry.kind) {
     case "rendered":
       return {
-        gutter: entry.marker,
+        // The Entry Marker is a formatted flow of the style's own, so it shows
+        // through the same renderer as the entry it belongs to.
+        gutter: entry.marker ? (
+          <InlineContent nodes={entry.marker} />
+        ) : undefined,
         warning: false,
         noteLabel: m.references_open_note(),
         noteDisabled: false,
@@ -343,10 +347,9 @@ function ReferenceBody({ entry }: { entry: ReferenceEntry }) {
   switch (entry.kind) {
     case "rendered":
       return (
-        <RenderedEntry
-          content={entry.content}
-          className={cn(textClass, "zt:text-foreground")}
-        />
+        <span className={cn(textClass, "zt:text-foreground")}>
+          <InlineContent nodes={entry.content} />
+        </span>
       );
     case "summary":
     case "unrendered":
@@ -376,18 +379,6 @@ function ReferenceBody({ entry }: { entry: ReferenceEntry }) {
         </span>
       );
   }
-}
-
-function RenderedEntry({
-  content,
-  className,
-}: {
-  content: DocumentFragment;
-  className?: string;
-}) {
-  return (
-    <span className={className} ref={useDomContent<HTMLSpanElement>(content)} />
-  );
 }
 
 function EntryAction({

--- a/apps/obsidian/src/views/references/References.tsx
+++ b/apps/obsidian/src/views/references/References.tsx
@@ -31,8 +31,11 @@ export function References() {
   const formattingFailed = useReferencesStore((s) => s.formattingFailed);
   const dbReady = useReferencesStore((s) => s.dbReady);
   const numbered = listMode.kind === "minimal";
+  const serials = listMode.kind === "bibliography" && listMode.entrySerials;
   const guttered =
-    numbered || (listMode.kind === "bibliography" && listMode.hasEntryMarkers);
+    numbered ||
+    serials ||
+    (listMode.kind === "bibliography" && listMode.hasEntryMarkers);
 
   return (
     <div className="zt:flex zt:h-full zt:flex-col zt:overflow-hidden">
@@ -70,6 +73,7 @@ export function References() {
                 key={entry.id}
                 entry={entry}
                 numbered={numbered}
+                serials={serials}
                 guttered={guttered}
               />
             ))}
@@ -162,19 +166,23 @@ const compactIconButton = "zt:p-1 zt:[--icon-size:var(--icon-xs)]";
  *
  * @param numbered whether the list carries Reference Numbers, which the minimal
  *   list does and an engine-rendered one leaves to the style.
+ * @param serials whether the gutter carries Entry Serials, which it does for a
+ *   document whose citations show them in place of the notes the style writes.
  * @param guttered whether the shared list grid includes its marker column.
  */
 function Reference({
   entry,
   numbered,
+  serials,
   guttered,
 }: {
   entry: ReferenceEntry;
   numbered: boolean;
+  serials: boolean;
   guttered: boolean;
 }) {
   const actions = useReferenceActions();
-  const presentation = referencePresentation(entry, numbered);
+  const presentation = referencePresentation(entry, { numbered, serials });
   const { source } = presentation;
   const occurrenceCount = entry.occurrences.length;
 
@@ -278,7 +286,7 @@ function Reference({
 
 function referencePresentation(
   entry: ReferenceEntry,
-  numbered: boolean,
+  { numbered, serials }: { numbered: boolean; serials: boolean },
 ): {
   gutter: ReactNode;
   warning: boolean;
@@ -290,9 +298,13 @@ function referencePresentation(
     case "rendered":
       return {
         // The Entry Marker is a formatted flow of the style's own, so it shows
-        // through the same renderer as the entry it belongs to.
+        // through the same renderer as the entry it belongs to, and it keeps
+        // the gutter wherever the style writes one. The Entry Serial takes the
+        // gutter only where it stands for the note a citation cannot show.
         gutter: entry.marker ? (
           <InlineContent nodes={entry.marker} />
+        ) : serials ? (
+          entry.serial
         ) : undefined,
         warning: false,
         noteLabel: m.references_open_note(),

--- a/apps/obsidian/src/views/references/actions.test.ts
+++ b/apps/obsidian/src/views/references/actions.test.ts
@@ -18,13 +18,19 @@ const offered: ReferencesCopyTarget = {
 function snapshot(
   overrides: Partial<CopyBibliographySnapshot> = {},
 ): CopyBibliographySnapshot {
-  const content = document.createDocumentFragment();
-  const emphasis = document.createElement("i");
-  emphasis.append("Field notes");
-  content.append("Rivers, A. (2020). ", emphasis, ". Harbour Press.");
   return {
     ...offered,
-    entries: [{ marker: "[1]", content }],
+    entries: [
+      {
+        marker: [{ t: "Str", c: "[1]" }],
+        content: [
+          { t: "Str", c: "Rivers, A. (2020)." },
+          { t: "Space" },
+          { t: "Emph", c: [{ t: "Str", c: "Field notes" }] },
+          { t: "Str", c: ". Harbour Press." },
+        ],
+      },
+    ],
     ...overrides,
   };
 }
@@ -66,7 +72,7 @@ describe("onCopyBibliography", () => {
     await build().onCopyBibliography(offered);
 
     expect(writeClipboard).toHaveBeenCalledExactlyOnceWith({
-      html: "<p>[1] Rivers, A. (2020). <i>Field notes</i>. Harbour Press.</p>",
+      html: "<p>[1] Rivers, A. (2020). <em>Field notes</em>. Harbour Press.</p>",
       text: "[1] Rivers, A. (2020). Field notes. Harbour Press.",
     });
     expect(notify).toHaveBeenCalledExactlyOnceWith(

--- a/apps/obsidian/src/views/references/copied-bibliography.test.ts
+++ b/apps/obsidian/src/views/references/copied-bibliography.test.ts
@@ -1,22 +1,56 @@
 // @vitest-environment happy-dom
 import { describe, expect, it } from "vitest";
 
+import type { Attr, Inline, Inlines } from "@/services/pandoc/ast";
+
 import { toCopiedBibliography } from "./copied-bibliography";
 import type { CopiedBibliographyEntry } from "./copied-bibliography";
 
-function entry(html: string, marker?: string): CopiedBibliographyEntry {
-  const content = document.createDocumentFragment();
-  const holder = document.createElement("div");
-  holder.innerHTML = html;
-  content.append(...holder.childNodes);
+const NO_ATTR: Attr = ["", [], []];
+
+/** One run of text as the flow a style writes it in: words, spaces apart. */
+function words(text: string): Inlines {
+  const flow: Inline[] = [];
+  for (const [index, word] of text.split(" ").entries()) {
+    if (index > 0) flow.push({ t: "Space" });
+    if (word) flow.push({ t: "Str", c: word });
+  }
+  return flow;
+}
+
+function emph(text: string): Inline {
+  return { t: "Emph", c: words(text) };
+}
+
+function link(text: string, url: string): Inline {
+  return { t: "Link", c: [NO_ATTR, words(text), [url, ""]] };
+}
+
+function span(classes: readonly string[], content: Inlines): Inline {
+  return { t: "Span", c: [["", classes, []], content] };
+}
+
+function note(text: string): Inline {
+  return { t: "Note", c: [{ t: "Para", c: words(text) }] };
+}
+
+function entry(content: Inlines, marker?: Inlines): CopiedBibliographyEntry {
   return { marker, content };
 }
 
 describe("toCopiedBibliography", () => {
   it("separates author-date entries with a blank line and adds no heading", () => {
     const { text } = toCopiedBibliography([
-      entry("Rivers, A. (2020). <i>Field notes</i>. Harbour Press."),
-      entry("Stone, B. (2018). <i>Tidal margins</i>. Harbour Press."),
+      entry([
+        ...words("Rivers, A. (2020). "),
+        emph("Field notes"),
+        ...words(". Harbour Press."),
+      ]),
+      entry([
+        ...words("Stone, B. (2018). "),
+        emph("Tidal margins"),
+        ...words(". Harbour Press."),
+      ]),
     ]);
 
     expect(text).toBe(
@@ -27,8 +61,22 @@ describe("toCopiedBibliography", () => {
 
   it("keeps the Entry Markers and the bibliography order of a numeric style", () => {
     const { text } = toCopiedBibliography([
-      entry("Stone, B. <i>Tidal margins</i>. Harbour Press, 2018.", "[1]"),
-      entry("Rivers, A. <i>Field notes</i>. Harbour Press, 2020.", "[2]"),
+      entry(
+        [
+          ...words("Stone, B. "),
+          emph("Tidal margins"),
+          ...words(". Harbour Press, 2018."),
+        ],
+        words("[1]"),
+      ),
+      entry(
+        [
+          ...words("Rivers, A. "),
+          emph("Field notes"),
+          ...words(". Harbour Press, 2020."),
+        ],
+        words("[2]"),
+      ),
     ]);
 
     expect(text).toBe(
@@ -39,18 +87,31 @@ describe("toCopiedBibliography", () => {
 
   it("reads the visible text of inline CSL semantics", () => {
     const { text } = toCopiedBibliography([
-      entry(
-        "Rivers, A. <i>H<sub>2</sub>O</i> at 10<sup>3</sup> m, " +
-          '<span style="font-variant: small-caps;">ii</span>.',
-      ),
+      entry([
+        ...words("Rivers, A. "),
+        { t: "Str", c: "H" },
+        { t: "Subscript", c: words("2") },
+        { t: "Str", c: "O" },
+        ...words(" at 10"),
+        { t: "Superscript", c: words("3") },
+        ...words(" m, "),
+        { t: "SmallCaps", c: words("ii") },
+        { t: "Str", c: "." },
+      ]),
     ]);
 
     expect(text).toBe("Rivers, A. H2O at 103 m, ii.");
   });
 
-  it("collapses the layout whitespace an entry is formatted across", () => {
+  it("collapses the layout a style lays an entry out across", () => {
     const { text } = toCopiedBibliography([
-      entry("\n  Rivers, A.\n  <i>Field\n  notes</i>.\n", "1."),
+      entry(
+        [
+          span(["csl-block"], words("Rivers, A.")),
+          span(["csl-indent"], [emph("Field notes"), { t: "Str", c: "." }]),
+        ],
+        words("1."),
+      ),
     ]);
 
     expect(text).toBe("1. Rivers, A. Field notes.");
@@ -58,13 +119,26 @@ describe("toCopiedBibliography", () => {
 
   it("keeps non-ASCII text and the spacing a style chose", () => {
     const { text } = toCopiedBibliography([
-      entry("李四. 《潮汐边缘》. 港口出版社, 2018."),
-      entry("Rivers,\u00a0A. — <i>Field notes</i>."),
+      entry(words("李四. 《潮汐边缘》. 港口出版社, 2018.")),
+      entry([
+        { t: "Str", c: "Rivers, A." },
+        ...words(" — "),
+        emph("Field notes"),
+        { t: "Str", c: "." },
+      ]),
     ]);
 
     expect(text).toBe(
-      "李四. 《潮汐边缘》. 港口出版社, 2018.\n\nRivers,\u00a0A. — Field notes.",
+      "李四. 《潮汐边缘》. 港口出版社, 2018.\n\nRivers, A. — Field notes.",
     );
+  });
+
+  it("carries no Entry Serial for a style that writes its citations as notes", () => {
+    const { text } = toCopiedBibliography([
+      entry([...words("Rivers, A. (2020). Field notes."), note("Ibid., 12.")]),
+    ]);
+
+    expect(text).toBe("Rivers, A. (2020). Field notes.");
   });
 
   it("returns nothing for an empty bibliography", () => {
@@ -85,8 +159,16 @@ function paragraphs(html: string): HTMLElement[] {
 describe("toCopiedBibliography rich HTML", () => {
   it("writes one paragraph per entry and nothing above them", () => {
     const { html } = toCopiedBibliography([
-      entry("Rivers, A. (2020). <i>Field notes</i>. Harbour Press."),
-      entry("Stone, B. (2018). <i>Tidal margins</i>. Harbour Press."),
+      entry([
+        ...words("Rivers, A. (2020). "),
+        emph("Field notes"),
+        ...words(". Harbour Press."),
+      ]),
+      entry([
+        ...words("Stone, B. (2018). "),
+        emph("Tidal margins"),
+        ...words(". Harbour Press."),
+      ]),
     ]);
     const rendered = paragraphs(html);
 
@@ -99,8 +181,14 @@ describe("toCopiedBibliography rich HTML", () => {
 
   it("keeps the Entry Markers and the bibliography order of a numeric style", () => {
     const { html } = toCopiedBibliography([
-      entry("Stone, B. <i>Tidal margins</i>. Harbour Press, 2018.", "[1]"),
-      entry("Rivers, A. <i>Field notes</i>. Harbour Press, 2020.", "[2]"),
+      entry(
+        words("Stone, B. Tidal margins. Harbour Press, 2018."),
+        words("[1]"),
+      ),
+      entry(
+        words("Rivers, A. Field notes. Harbour Press, 2020."),
+        words("[2]"),
+      ),
     ]);
 
     expect(paragraphs(html).map((p) => p.textContent)).toEqual([
@@ -111,15 +199,22 @@ describe("toCopiedBibliography rich HTML", () => {
 
   it("keeps the inline CSL semantics a style rendered", () => {
     const { html } = toCopiedBibliography([
-      entry(
-        "Rivers, A. <i>H<sub>2</sub>O</i> at 10<sup>3</sup> m, " +
-          '<span style="font-variant: small-caps;">ii</span>. ' +
-          '<a href="https://doi.org/10.1000/182">https://doi.org/10.1000/182</a>',
-      ),
+      entry([
+        ...words("Rivers, A. "),
+        emph("H"),
+        { t: "Subscript", c: words("2") },
+        { t: "Str", c: "O" },
+        ...words(" at 10"),
+        { t: "Superscript", c: words("3") },
+        ...words(" m, "),
+        { t: "SmallCaps", c: words("ii") },
+        ...words(". "),
+        link("https://doi.org/10.1000/182", "https://doi.org/10.1000/182"),
+      ]),
     ]);
     const [rendered] = paragraphs(html);
 
-    expect(rendered!.querySelector("i")?.textContent).toBe("H2O");
+    expect(rendered!.querySelector("em")?.textContent).toBe("H");
     expect(rendered!.querySelector("sub")?.textContent).toBe("2");
     expect(rendered!.querySelector("sup")?.textContent).toBe("3");
     expect(
@@ -130,35 +225,49 @@ describe("toCopiedBibliography rich HTML", () => {
     );
   });
 
+  it("writes a strikeout as the element pandoc's own writer gives it", () => {
+    const { html } = toCopiedBibliography([
+      entry([
+        { t: "Strikeout", c: words("Retracted") },
+        ...words(". Rivers, A. (2020)."),
+      ]),
+    ]);
+    const [rendered] = paragraphs(html);
+
+    expect(rendered!.querySelector("del")?.textContent).toBe("Retracted");
+    expect(rendered!.textContent).toBe("Retracted. Rivers, A. (2020).");
+  });
+
   it("carries the styling of a CSL semantic and no markup of its own", () => {
     const { html } = toCopiedBibliography([
-      entry(
-        '<span class="nocase" id="ref-tidal" style="font-variant: small-caps;">ii</span>' +
-          ' <mark class="zt-hit">Field notes</mark>.',
-      ),
+      entry([
+        span(["nocase"], [{ t: "SmallCaps", c: words("ii") }]),
+        ...words(" Field notes."),
+      ]),
     ]);
     const [rendered] = paragraphs(html);
     const semantic = rendered!.querySelector("span")!;
 
     expect(semantic.getAttributeNames()).toEqual(["style"]);
     expect(semantic.style.getPropertyValue("font-variant")).toBe("small-caps");
-    expect(rendered!.querySelector("mark")).toBeNull();
     expect(rendered!.textContent).toBe("ii Field notes.");
   });
 
   it("keeps a link's text and drops a target no destination should follow", () => {
     const { html } = toCopiedBibliography([
-      entry(
-        '<a href="javascript:alert(1)">Field notes</a>, ' +
-          '<a href="/vault/notes/tidal.md">Tidal margins</a>, ' +
-          '<a href="mailto:rivers@example.org">Rivers, A.</a>',
-      ),
+      entry([
+        link("Field notes", "javascript:alert(1)"),
+        ...words(", "),
+        link("Tidal margins", "/vault/notes/tidal.md"),
+        ...words(", "),
+        link("Rivers, A.", "mailto:rivers@example.org"),
+      ]),
     ]);
     const [rendered] = paragraphs(html);
 
     expect(
       [...rendered!.querySelectorAll("a")].map((a) => a.getAttribute("href")),
-    ).toEqual([null, null, "mailto:rivers@example.org"]);
+    ).toEqual(["mailto:rivers@example.org"]);
     expect(rendered!.textContent).toBe(
       "Field notes, Tidal margins, Rivers, A.",
     );
@@ -166,14 +275,39 @@ describe("toCopiedBibliography rich HTML", () => {
 
   it("keeps the punctuation and non-ASCII text of an entry", () => {
     const { html } = toCopiedBibliography([
-      entry("李四. 《潮汐边缘》. 港口出版社, 2018."),
-      entry("Rivers, A. — <i>Field &amp; notes</i>."),
+      entry(words("李四. 《潮汐边缘》. 港口出版社, 2018.")),
+      entry([
+        ...words("Rivers, A. — "),
+        { t: "Emph", c: words("Field & notes") },
+        { t: "Str", c: "." },
+      ]),
     ]);
 
     expect(paragraphs(html).map((p) => p.textContent)).toEqual([
       "李四. 《潮汐边缘》. 港口出版社, 2018.",
-      "Rivers, A. — Field & notes.",
+      "Rivers, A. — Field & notes.",
     ]);
+  });
+
+  it("writes an entry's text as text, whatever a style put in it", () => {
+    const { html } = toCopiedBibliography([
+      entry(words("Rivers, A. <script>alert(1)</script> & Co.")),
+    ]);
+
+    expect(html).not.toContain("<script>");
+    expect(paragraphs(html)[0]!.textContent).toBe(
+      "Rivers, A. <script>alert(1)</script> & Co.",
+    );
+  });
+
+  it("carries no Entry Serial for a style that writes its citations as notes", () => {
+    const { html } = toCopiedBibliography([
+      entry([...words("Rivers, A. (2020). Field notes."), note("Ibid., 12.")]),
+    ]);
+
+    expect(paragraphs(html)[0]!.textContent).toBe(
+      "Rivers, A. (2020). Field notes.",
+    );
   });
 
   it("returns nothing for an empty bibliography", () => {

--- a/apps/obsidian/src/views/references/copied-bibliography.test.ts
+++ b/apps/obsidian/src/views/references/copied-bibliography.test.ts
@@ -121,7 +121,7 @@ describe("toCopiedBibliography", () => {
     const { text } = toCopiedBibliography([
       entry(words("李四. 《潮汐边缘》. 港口出版社, 2018.")),
       entry([
-        { t: "Str", c: "Rivers, A." },
+        { t: "Str", c: "Rivers,\u00a0A." },
         ...words(" — "),
         emph("Field notes"),
         { t: "Str", c: "." },
@@ -129,7 +129,7 @@ describe("toCopiedBibliography", () => {
     ]);
 
     expect(text).toBe(
-      "李四. 《潮汐边缘》. 港口出版社, 2018.\n\nRivers, A. — Field notes.",
+      "李四. 《潮汐边缘》. 港口出版社, 2018.\n\nRivers,\u00a0A. — Field notes.",
     );
   });
 

--- a/apps/obsidian/src/views/references/copied-bibliography.ts
+++ b/apps/obsidian/src/views/references/copied-bibliography.ts
@@ -3,6 +3,7 @@
 import type { Inlines } from "@/services/pandoc/ast";
 import {
   DISPLAY_CLASSES,
+  flowWriter,
   inlineText,
   linkHref,
   QUOTE_MARKS,
@@ -47,11 +48,12 @@ export function toCopiedBibliography(
 /**
  * One paragraph, holding the Entry Marker and the entry as portable markup.
  *
- * The entry is written from the formatted flow the engine handed over, so what
- * reaches the clipboard is the same vocabulary every surface shows: the
- * elements pandoc's own HTML writer names, a link's target under a followable
- * scheme, and the declarations small caps rides under. A style writes whatever
- * it likes into an entry; nothing else of it crosses over.
+ * The entry is written from the formatted flow the engine handed over, and the
+ * destination reads no stylesheet of ours, so what crosses over is what stands
+ * on its own: the elements pandoc's own HTML writer names, a link's target
+ * under a followable scheme, and the declarations small caps rides under. A
+ * style writes whatever it likes into an entry; nothing else of it crosses
+ * over.
  */
 function richEntry({ marker, content }: CopiedBibliographyEntry): string {
   const paragraph = document.createElement("p");
@@ -70,23 +72,9 @@ function richEntry({ marker, content }: CopiedBibliographyEntry): string {
  */
 function portable(nodes: Inlines): DocumentFragment {
   const fragment = document.createDocumentFragment();
-  /** Whether the flow already ends in a separator, so none is owed. */
-  let spaced = true;
-  /** Whether a display span just ended, so the next content starts a part. */
-  let boundary = false;
-
-  function separate(): void {
-    if (spaced) return;
-    fragment.append(" ");
-    spaced = true;
-  }
-
-  function add(node: Node | string): void {
-    if (boundary) separate();
-    boundary = false;
+  const { separate, add, endPart } = flowWriter<Node>((node) => {
     fragment.append(node);
-    spaced = false;
-  }
+  });
 
   function wrap(tag: string, content: Inlines): HTMLElement {
     const element = document.createElement(tag);
@@ -153,7 +141,7 @@ function portable(nodes: Inlines): DocumentFragment {
           const display = classes.some((name) => DISPLAY_CLASSES.has(name));
           if (display) separate();
           walk(content);
-          if (display) boundary = true;
+          if (display) endPart();
           break;
         }
         case "Link": {

--- a/apps/obsidian/src/views/references/copied-bibliography.ts
+++ b/apps/obsidian/src/views/references/copied-bibliography.ts
@@ -1,11 +1,20 @@
 // Serialization of a Copied Bibliography: a complete bibliography rendering, written for a destination outside the vault.
 
-/** One entry of a completed bibliography, as the render cache formatted it. */
+import type { Inlines } from "@/services/pandoc/ast";
+import {
+  DISPLAY_CLASSES,
+  inlineText,
+  linkHref,
+  QUOTE_MARKS,
+  WRAPPER_TAGS,
+} from "@/services/pandoc/inline-content";
+
+/** One entry of a completed bibliography, as the engine formatted it. */
 export interface CopiedBibliographyEntry {
   /** The style's Entry Marker, or `undefined` when the style renders none. */
-  marker: string | undefined;
+  readonly marker: Inlines | undefined;
   /** The entry text as one inline flow. */
-  content: DocumentFragment;
+  readonly content: Inlines;
 }
 
 /** A Copied Bibliography in the representations the clipboard offers. */
@@ -36,102 +45,147 @@ export function toCopiedBibliography(
 }
 
 /**
- * The inline elements a CSL semantic reaches the entry as: emphasis, weight,
- * underline, superscript, subscript, a link, and the span that carries small
- * caps. Anything else hands its own content over and keeps the text.
- */
-const PORTABLE_TAGS = new Set([
-  "a",
-  "b",
-  "em",
-  "i",
-  "span",
-  "strong",
-  "sub",
-  "sup",
-  "u",
-]);
-
-/**
- * The declarations that carry a CSL semantic no element stands for — small caps
- * above all. They ride as inline style because the destination is another
- * application, which has no stylesheet of ours to read a class against.
- */
-const PORTABLE_STYLE = [
-  "font-variant",
-  "font-style",
-  "font-weight",
-  "text-decoration",
-];
-
-/**
- * The schemes a bibliography link reaches another application under. A style
- * writes a DOI, a URL, or an address; a target under any other scheme carries
- * no CSL semantic and stays behind, so an active one — `javascript:` above all
- * — never reaches the clipboard.
- */
-const PORTABLE_SCHEMES = new Set(["http:", "https:", "mailto:"]);
-
-/**
  * One paragraph, holding the Entry Marker and the entry as portable markup.
  *
- * The entry is rebuilt rather than cloned: each element is remade from the
- * allowed tags, and the only attributes that cross over are a link's target
- * under an allowed scheme and the inline declarations above, so what reaches
- * the clipboard carries markup the destination can read and nothing else,
- * whatever a style put in the entry.
+ * The entry is written from the formatted flow the engine handed over, so what
+ * reaches the clipboard is the same vocabulary every surface shows: the
+ * elements pandoc's own HTML writer names, a link's target under a followable
+ * scheme, and the declarations small caps rides under. A style writes whatever
+ * it likes into an entry; nothing else of it crosses over.
  */
 function richEntry({ marker, content }: CopiedBibliographyEntry): string {
   const paragraph = document.createElement("p");
-  const label = marker === undefined ? "" : collapse(marker);
+  const label = marker === undefined ? "" : collapse(inlineText(marker));
   if (label) paragraph.append(`${label} `);
   paragraph.append(portable(content));
   return paragraph.outerHTML;
 }
 
-function portable(source: Node): DocumentFragment {
+/**
+ * Write one formatted flow as the markup a destination outside the vault reads.
+ *
+ * The walk follows the one the surfaces render under: a constructor that stands
+ * for an element becomes that element, and one that stands for a layout hands
+ * its own content over, leaving a single space where a display span stood.
+ */
+function portable(nodes: Inlines): DocumentFragment {
   const fragment = document.createDocumentFragment();
-  for (const node of source.childNodes) {
-    if (node.nodeType === Node.TEXT_NODE) {
-      fragment.append(node.textContent ?? "");
-      continue;
-    }
-    if (!(node instanceof Element)) continue;
-    const tag = node.tagName.toLowerCase();
-    if (!PORTABLE_TAGS.has(tag)) {
-      fragment.append(portable(node));
-      continue;
-    }
+  /** Whether the flow already ends in a separator, so none is owed. */
+  let spaced = true;
+  /** Whether a display span just ended, so the next content starts a part. */
+  let boundary = false;
+
+  function separate(): void {
+    if (spaced) return;
+    fragment.append(" ");
+    spaced = true;
+  }
+
+  function add(node: Node | string): void {
+    if (boundary) separate();
+    boundary = false;
+    fragment.append(node);
+    spaced = false;
+  }
+
+  function wrap(tag: string, content: Inlines): HTMLElement {
     const element = document.createElement(tag);
-    const href = tag === "a" ? portableHref(node.getAttribute("href")) : null;
-    if (href) element.setAttribute("href", href);
-    if (node instanceof HTMLElement) {
-      for (const property of PORTABLE_STYLE) {
-        const value = node.style.getPropertyValue(property);
-        if (value) element.style.setProperty(property, value);
+    element.append(portable(content));
+    return element;
+  }
+
+  function walk(inlines: Inlines): void {
+    for (const inline of inlines) {
+      switch (inline.t) {
+        case "Str":
+          add(inline.c);
+          break;
+        case "Space":
+        case "SoftBreak":
+          separate();
+          break;
+        case "Emph":
+        case "Strong":
+        case "Underline":
+        case "Strikeout":
+        case "Superscript":
+        case "Subscript":
+          add(wrap(WRAPPER_TAGS[inline.t], inline.c));
+          break;
+        case "SmallCaps": {
+          // The one CSL semantic no element stands for. It rides as inline
+          // style because the destination is another application, which has no
+          // stylesheet of ours to read a class against.
+          const element = wrap("span", inline.c);
+          element.style.setProperty("font-variant", "small-caps");
+          add(element);
+          break;
+        }
+        case "Quoted": {
+          const [open, close] = QUOTE_MARKS[inline.c[0].t];
+          add(open);
+          walk(inline.c[1]);
+          add(close);
+          break;
+        }
+        case "Code": {
+          const [, source] = inline.c;
+          add(source);
+          break;
+        }
+        case "Math": {
+          const [, source] = inline.c;
+          add(source);
+          break;
+        }
+        case "Cite": {
+          const [, content] = inline.c;
+          walk(content);
+          break;
+        }
+        case "Image": {
+          const [, alt] = inline.c;
+          walk(alt);
+          break;
+        }
+        case "Span": {
+          const [[, classes], content] = inline.c;
+          const display = classes.some((name) => DISPLAY_CLASSES.has(name));
+          if (display) separate();
+          walk(content);
+          if (display) boundary = true;
+          break;
+        }
+        case "Link": {
+          const [, children, [url]] = inline.c;
+          const href = linkHref(url);
+          if (href === null) {
+            walk(children);
+            break;
+          }
+          const anchor = wrap("a", children);
+          anchor.setAttribute("href", href);
+          add(anchor);
+          break;
+        }
+        case "LineBreak":
+        case "Note":
+        case "RawInline":
+          // A line break is layout the paragraph has no room for, a note is a
+          // document-scoped coordinate that travels with no document, and raw
+          // markup belongs to a format the destination is not reading.
+          break;
       }
     }
-    element.append(portable(node));
-    fragment.append(element);
   }
+
+  walk(nodes);
   return fragment;
 }
 
-/**
- * A target is absolute here or nowhere: the destination is another
- * application, which resolves a relative target against a document of its own.
- *
- * @returns the target when its scheme is portable, `null` otherwise.
- */
-function portableHref(href: string | null): string | null {
-  if (!href) return null;
-  const target = URL.parse(href);
-  return target && PORTABLE_SCHEMES.has(target.protocol) ? href : null;
-}
-
 function plainEntry({ marker, content }: CopiedBibliographyEntry): string {
-  const body = collapse(content.textContent ?? "");
-  const label = marker === undefined ? "" : collapse(marker);
+  const body = collapse(inlineText(content));
+  const label = marker === undefined ? "" : collapse(inlineText(marker));
   return [label, body].filter(Boolean).join(" ");
 }
 

--- a/apps/obsidian/src/views/references/entries.test.ts
+++ b/apps/obsidian/src/views/references/entries.test.ts
@@ -106,6 +106,7 @@ describe("buildReferenceEntries", () => {
         occurrences: [occurrenceAt(2)],
         kind: "rendered",
         source: sources.get("ALPHA002"),
+        serial: 1,
         marker: [{ t: "Str", c: "[1]" }],
         content: alpha.content,
       },
@@ -116,6 +117,7 @@ describe("buildReferenceEntries", () => {
         occurrences: [occurrenceAt(1)],
         kind: "rendered",
         source: sources.get("ZEBRA001"),
+        serial: 2,
         marker: [{ t: "Str", c: "[2]" }],
         content: zebra.content,
       },
@@ -156,6 +158,36 @@ describe("buildReferenceEntries", () => {
       ["BOOK0003", "rendered"],
       ["GONE0001", "missing"],
       ["BOOK0002", "unrendered"],
+    ]);
+  });
+
+  // The Entry Serial names a place in the bibliography, so it counts the
+  // formatted entries alone: a Reference Error takes no number and shifts none.
+  it("numbers the formatted entries by their place in the bibliography", () => {
+    const citations = [
+      citation("GONE0001", 1),
+      citation("BOOK0002", 2),
+      citation("BOOK0003", 3),
+    ];
+    const sources = new Map([
+      ["BOOK0002", source("BOOK0002", "ref-two")],
+      ["BOOK0003", source("BOOK0003", "ref-three")],
+    ]);
+    const bibliography = completed(
+      new Map([
+        ["ref-three", rendered("Three")],
+        ["ref-two", rendered("Two")],
+      ]),
+    );
+
+    expect(
+      buildReferenceEntries(citations, sources, { bibliography }).map(
+        (entry) => [entry.id, entry.kind === "rendered" ? entry.serial : null],
+      ),
+    ).toStrictEqual([
+      ["BOOK0003", 1],
+      ["BOOK0002", 2],
+      ["GONE0001", null],
     ]);
   });
 

--- a/apps/obsidian/src/views/references/entries.test.ts
+++ b/apps/obsidian/src/views/references/entries.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment happy-dom
 import { describe, expect, it } from "vitest";
 
 import type {
@@ -53,13 +52,12 @@ function occurrenceAt(
   };
 }
 
-/** A rendered entry as the engine hands it over: parsed, not markup. */
+/** A rendered entry as the engine hands it over: typed AST, not markup. */
 function rendered(text: string, marker?: string): RenderedReference {
-  const content = createFragment();
-  const span = document.createElement("span");
-  span.textContent = text;
-  content.append(span);
-  return { marker, content };
+  return {
+    marker: marker === undefined ? undefined : [{ t: "Str", c: marker }],
+    content: [{ t: "Str", c: text }],
+  };
 }
 
 function completed(
@@ -108,7 +106,7 @@ describe("buildReferenceEntries", () => {
         occurrences: [occurrenceAt(2)],
         kind: "rendered",
         source: sources.get("ALPHA002"),
-        marker: "[1]",
+        marker: [{ t: "Str", c: "[1]" }],
         content: alpha.content,
       },
       {
@@ -118,7 +116,7 @@ describe("buildReferenceEntries", () => {
         occurrences: [occurrenceAt(1)],
         kind: "rendered",
         source: sources.get("ZEBRA001"),
-        marker: "[2]",
+        marker: [{ t: "Str", c: "[2]" }],
         content: zebra.content,
       },
     ]);

--- a/apps/obsidian/src/views/references/entries.ts
+++ b/apps/obsidian/src/views/references/entries.ts
@@ -41,6 +41,19 @@ interface NumberedReferenceEntryBase extends ReferenceEntryBase {
   refNumber: number;
 }
 
+/** The part of a formatted entry that the bibliography itself supplies. */
+type RenderedReferenceEntryBody = {
+  kind: "rendered";
+  source: ReferenceSource;
+  linkpath: string | null;
+  /**
+   * Entry Serial: this entry's 1-based place in the bibliography-ordered list,
+   * counting the formatted entries alone. It is the digit a citation of this
+   * work shows where the style writes its citations as notes.
+   */
+  serial: number;
+} & RenderedReference;
+
 /**
  * One reference as the sidebar shows it. The engine's absence is a normal mode,
  * so a `summary` entry is ordinary content rather than a degraded one; a
@@ -56,11 +69,7 @@ interface NumberedReferenceEntryBase extends ReferenceEntryBase {
  */
 type CitationReferenceEntry = NumberedReferenceEntryBase &
   (
-    | ({
-        kind: "rendered";
-        source: ReferenceSource;
-        linkpath: string | null;
-      } & RenderedReference)
+    | RenderedReferenceEntryBody
     | { kind: "summary"; source: ReferenceSource; linkpath: string | null }
     | { kind: "unrendered"; source: ReferenceSource; linkpath: string | null }
     | { kind: "missing"; linkpath: string | null }
@@ -103,7 +112,10 @@ export function buildReferenceEntries(
   options: ReferenceBuildOptions = {},
 ): ReferenceEntry[] {
   const { bibliography, errors = [] } = options;
-  const placed = new Map<string, ReferenceEntry>();
+  const placed = new Map<
+    string,
+    NumberedReferenceEntryBase & Omit<RenderedReferenceEntryBody, "serial">
+  >();
   const trailing: ReferenceEntry[] = [];
   for (const { indexedKey, refNumber, linkpath, occurrences } of citations) {
     if (indexedKey === null) {
@@ -151,10 +163,12 @@ export function buildReferenceEntries(
       right.occurrences[0]!.position.start.offset,
   );
 
+  // The Entry Serial is the place a formatted entry takes here, so it is
+  // counted as the list itself is put in bibliography order.
   const ordered: ReferenceEntry[] = [];
   for (const id of bibliography?.entries.keys() ?? []) {
     const entry = placed.get(id);
-    if (entry) ordered.push(entry);
+    if (entry) ordered.push({ ...entry, serial: ordered.length + 1 });
   }
   return [...ordered, ...trailing];
 }

--- a/apps/obsidian/src/views/references/entries.ts
+++ b/apps/obsidian/src/views/references/entries.ts
@@ -6,16 +6,18 @@ import type {
   DocumentCitationError,
   ReferenceSource,
 } from "@/services/citation-index/service";
+import type { Inlines } from "@/services/pandoc/ast";
 
 /**
  * One bibliography entry as the engine formatted it — the shape the engine's
- * own entry contract carries, without the CSL id that addresses it.
+ * own entry contract carries, without the CSL id that addresses it. Both parts
+ * are typed AST the shared renderer shows, held as the engine handed them over.
  */
 export interface RenderedReference {
   /** The style's Entry Marker, or `undefined` when the style renders none. */
-  marker: string | undefined;
+  marker: Inlines | undefined;
   /** The entry text as one inline flow, so the occurrence counter sits after it. */
-  content: DocumentFragment;
+  content: Inlines;
 }
 
 export interface ReferenceBibliography {

--- a/apps/obsidian/src/views/references/register.ts
+++ b/apps/obsidian/src/views/references/register.ts
@@ -4,6 +4,7 @@ import type { App, Plugin } from "obsidian";
 import * as m from "@/lib/i18n/generated/messages";
 import { revealSetting } from "@/lib/open-settings";
 import type { CitationIndex } from "@/services/citation-index/service";
+import type { CitationText } from "@/services/citation-text/service";
 import type { CitekeyEditor } from "@/services/citekey-editor/service";
 import type { DatabaseService } from "@/services/database/service";
 import type { BibliographyRenderCache } from "@/services/pandoc/render-cache";
@@ -22,6 +23,7 @@ export interface ReferencesRegistrationDeps {
   app: App;
   db: DatabaseService;
   citationIndex: CitationIndex;
+  citationText: CitationText;
   citekeyEditor: CitekeyEditor;
   pandocEngine: PandocEngineService;
   bibliographyRender: BibliographyRenderCache;
@@ -36,6 +38,7 @@ export function registerReferencesView(
     app: deps.app,
     db: deps.db,
     citationIndex: deps.citationIndex,
+    citationText: deps.citationText,
     citekeyEditor: deps.citekeyEditor,
     pandocEngine: deps.pandocEngine,
     bibliographyRender: deps.bibliographyRender,

--- a/apps/obsidian/src/views/references/store.test.ts
+++ b/apps/obsidian/src/views/references/store.test.ts
@@ -1,4 +1,3 @@
-// @vitest-environment happy-dom
 import { describe, expect, it } from "vitest";
 
 import type {
@@ -6,6 +5,7 @@ import type {
   CitationOccurrence,
   ReferenceSource,
 } from "@/services/citation-index/service";
+import type { Inlines } from "@/services/pandoc/ast";
 
 import type { ReferenceEntry } from "./entries";
 import {
@@ -45,8 +45,13 @@ const source: ReferenceSource = {
 
 describe("minimalReferencesState", () => {
   it("replaces a stale formatted list after a failed render", () => {
-    const content = document.createDocumentFragment();
-    content.append("Stale formatted book");
+    const content: Inlines = [
+      { t: "Str", c: "Stale" },
+      { t: "Space" },
+      { t: "Str", c: "formatted" },
+      { t: "Space" },
+      { t: "Str", c: "book" },
+    ];
     const store = createReferencesStore();
     store.setState({
       entries: [
@@ -90,8 +95,8 @@ describe("referencesCopyState", () => {
     occurrences: [occurrence],
     kind: "rendered",
     source,
-    marker: "[1]",
-    content: document.createDocumentFragment(),
+    marker: [{ t: "Str", c: "[1]" }],
+    content: [{ t: "Str", c: "Book" }],
   };
   const unrendered: ReferenceEntry = {
     id: "BOOK0002",

--- a/apps/obsidian/src/views/references/store.test.ts
+++ b/apps/obsidian/src/views/references/store.test.ts
@@ -62,11 +62,16 @@ describe("minimalReferencesState", () => {
           occurrences: [occurrence],
           kind: "rendered",
           source,
+          serial: 1,
           marker: undefined,
           content,
         },
       ],
-      listMode: { kind: "bibliography", hasEntryMarkers: false },
+      listMode: {
+        kind: "bibliography",
+        hasEntryMarkers: false,
+        entrySerials: false,
+      },
       formattingFailed: false,
     });
 
@@ -95,6 +100,7 @@ describe("referencesCopyState", () => {
     occurrences: [occurrence],
     kind: "rendered",
     source,
+    serial: 1,
     marker: [{ t: "Str", c: "[1]" }],
     content: [{ t: "Str", c: "Book" }],
   };

--- a/apps/obsidian/src/views/references/store.ts
+++ b/apps/obsidian/src/views/references/store.ts
@@ -16,7 +16,16 @@ import type { ReferenceEntry } from "./entries";
 
 export type ReferencesListMode =
   | { kind: "minimal" }
-  | { kind: "bibliography"; hasEntryMarkers: boolean };
+  | {
+      kind: "bibliography";
+      hasEntryMarkers: boolean;
+      /**
+       * Whether the document's citations show Entry Serials, which puts the
+       * same digits in this list's gutter. An entry's own Entry Marker keeps
+       * the gutter where the style writes one.
+       */
+      entrySerials: boolean;
+    };
 
 /** Why the current list cannot become a Copied Bibliography. */
 export type ReferencesCopyBlock =

--- a/apps/obsidian/src/views/references/view.test.ts
+++ b/apps/obsidian/src/views/references/view.test.ts
@@ -5,9 +5,13 @@ import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DocumentCitationSet } from "@/services/citation-index/service";
+import type { Inline, Inlines } from "@/services/pandoc/ast";
+import type { AstBibliographyEntry } from "@/services/pandoc/engine";
 import type { BibliographyRenderOutcome } from "@/services/pandoc/render-cache";
 
 import { ReferencesView } from "./view";
+
+type RenderedBibliography = BibliographyRenderOutcome<AstBibliographyEntry>;
 
 vi.mock("zustand", () => import("../__fixtures__/zustand"));
 
@@ -70,18 +74,33 @@ const citationSet: DocumentCitationSet = {
   errors: [],
 };
 
-function renderedOutcome(): BibliographyRenderOutcome {
-  const content = document.createDocumentFragment();
-  content.append("Rivers, A. (2020). Field notes. Harbour Press.");
+/** One flow of plain words, the way pandoc splits text into Str and Space. */
+function words(text: string): Inlines {
+  return text
+    .split(" ")
+    .flatMap<Inline>((word, index) =>
+      index === 0
+        ? [{ t: "Str", c: word }]
+        : [{ t: "Space" }, { t: "Str", c: word }],
+    );
+}
+
+function renderedOutcome(): RenderedBibliography {
   return {
     kind: "rendered",
-    entries: [{ id: "ref-book", marker: "[1]", content }],
+    entries: [
+      {
+        id: "ref-book",
+        marker: words("[1]"),
+        content: words("Rivers, A. (2020). Field notes. Harbour Press."),
+      },
+    ],
     hasEntryMarkers: true,
   };
 }
 
 let view: TestReferencesView | undefined;
-let renders: PromiseWithResolvers<BibliographyRenderOutcome>[] = [];
+let renders: PromiseWithResolvers<RenderedBibliography>[] = [];
 let scans: PromiseWithResolvers<DocumentCitationSet>[] = [];
 let activeFile: TFile;
 let otherFile: TFile;
@@ -173,8 +192,8 @@ beforeEach(async () => {
         decline: () => undefined,
       },
       bibliographyRender: {
-        render: () => {
-          const deferred = Promise.withResolvers<BibliographyRenderOutcome>();
+        renderAst: () => {
+          const deferred = Promise.withResolvers<RenderedBibliography>();
           renders.push(deferred);
           return deferred.promise;
         },

--- a/apps/obsidian/src/views/references/view.test.ts
+++ b/apps/obsidian/src/views/references/view.test.ts
@@ -5,6 +5,7 @@ import { act } from "preact/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DocumentCitationSet } from "@/services/citation-index/service";
+import type { DocumentCitations } from "@/services/citation-text/present";
 import type { Inline, Inlines } from "@/services/pandoc/ast";
 import type { AstBibliographyEntry } from "@/services/pandoc/engine";
 import type { BibliographyRenderOutcome } from "@/services/pandoc/render-cache";
@@ -99,12 +100,40 @@ function renderedOutcome(): RenderedBibliography {
   };
 }
 
+/** What a style that writes no Entry Marker renders, which leaves the gutter free. */
+function unmarkedOutcome(): RenderedBibliography {
+  return {
+    kind: "rendered",
+    entries: [
+      {
+        id: "ref-book",
+        marker: undefined,
+        content: words("Rivers, A. (2020). Field notes. Harbour Press."),
+      },
+    ],
+    hasEntryMarkers: false,
+  };
+}
+
+/** What the citation text service holds for one note. */
+function heldText(entrySerials: boolean): DocumentCitations {
+  return {
+    formatted: new Map(),
+    entrySerials,
+    summaries: new Map(),
+    literalWorks: new Map(),
+  };
+}
+
 let view: TestReferencesView | undefined;
 let renders: PromiseWithResolvers<RenderedBibliography>[] = [];
 let scans: PromiseWithResolvers<DocumentCitationSet>[] = [];
 let activeFile: TFile;
 let otherFile: TFile;
 let onDbChanged: (() => void) | undefined;
+let onCitationsChanged: ((path: string) => void) | undefined;
+/** What the citation text service holds for the note on screen. */
+let heldCitations: DocumentCitations | null;
 let onInvalidated: (() => void) | undefined;
 let onActiveLeafChange: (() => void) | undefined;
 
@@ -131,8 +160,10 @@ async function settle(): Promise<void> {
   });
 }
 
-async function finishRender(): Promise<void> {
-  renders.at(-1)!.resolve(renderedOutcome());
+async function finishRender(
+  outcome: RenderedBibliography = renderedOutcome(),
+): Promise<void> {
+  renders.at(-1)!.resolve(outcome);
   await settle();
 }
 
@@ -151,6 +182,7 @@ async function followOtherNote(): Promise<void> {
 beforeEach(async () => {
   renders = [];
   scans = [];
+  heldCitations = null;
   activeFile = markdownFile("tidal");
   otherFile = markdownFile("estuary");
   const app = {
@@ -185,6 +217,14 @@ beforeEach(async () => {
         },
         on: () => () => undefined,
       },
+      citationText: {
+        peek: () => heldCitations,
+        load: () => Promise.resolve(heldCitations),
+        on: (event: string, callback: (path: string) => void) => {
+          if (event === "changed") onCitationsChanged = callback;
+          return () => undefined;
+        },
+      },
       citekeyEditor: { openCitekey: () => Promise.resolve() },
       pandocEngine: {
         getStatus: () => ({ kind: "installed", version: "test" }),
@@ -216,6 +256,7 @@ afterEach(async () => {
   await act(() => view?.close());
   view = undefined;
   onDbChanged = undefined;
+  onCitationsChanged = undefined;
   onInvalidated = undefined;
   onActiveLeafChange = undefined;
   document.body.replaceChildren();
@@ -288,5 +329,32 @@ describe("ReferencesView copy readiness", () => {
     await finishRender();
 
     expect(copyAction().hasAttribute("disabled")).toBe(true);
+  });
+});
+
+describe("ReferencesView Entry Serials", () => {
+  /** The gutter of the one entry the list shows. */
+  function gutter(): string | null {
+    return view!.contentEl.querySelector("li")!.children[0]!.textContent;
+  }
+
+  it("puts the gutter on Entry Serials once the note's citations show them", async () => {
+    heldCitations = heldText(true);
+    await act(() => onCitationsChanged!(activeFile.path));
+
+    await finishRender(unmarkedOutcome());
+
+    expect(gutter()).toBe("1");
+  });
+
+  it("leaves the gutter out where the note's citations show none", async () => {
+    heldCitations = heldText(false);
+    await act(() => onCitationsChanged!(activeFile.path));
+
+    await finishRender(unmarkedOutcome());
+
+    expect(view!.contentEl.querySelector("ul")!.classList).toContain(
+      "zt:grid-cols-[minmax(0,1fr)_max-content]",
+    );
   });
 });

--- a/apps/obsidian/src/views/references/view.test.ts
+++ b/apps/obsidian/src/views/references/view.test.ts
@@ -7,12 +7,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DocumentCitationSet } from "@/services/citation-index/service";
 import type { DocumentCitations } from "@/services/citation-text/present";
 import type { Inline, Inlines } from "@/services/pandoc/ast";
-import type { AstBibliographyEntry } from "@/services/pandoc/engine";
 import type { BibliographyRenderOutcome } from "@/services/pandoc/render-cache";
 
 import { ReferencesView } from "./view";
 
-type RenderedBibliography = BibliographyRenderOutcome<AstBibliographyEntry>;
+type RenderedBibliography = BibliographyRenderOutcome;
 
 vi.mock("zustand", () => import("../__fixtures__/zustand"));
 
@@ -232,7 +231,7 @@ beforeEach(async () => {
         decline: () => undefined,
       },
       bibliographyRender: {
-        renderAst: () => {
+        render: () => {
           const deferred = Promise.withResolvers<RenderedBibliography>();
           renders.push(deferred);
           return deferred.promise;

--- a/apps/obsidian/src/views/references/view.tsx
+++ b/apps/obsidian/src/views/references/view.tsx
@@ -22,6 +22,11 @@ import type {
 } from "@/services/citation-index/service";
 import type { CitekeyEditor } from "@/services/citekey-editor/service";
 import type { DatabaseService } from "@/services/database/service";
+import type { Inlines } from "@/services/pandoc/ast";
+import {
+  inlineText,
+  renderInlineContent,
+} from "@/services/pandoc/inline-content";
 import type { BibliographyRenderCache } from "@/services/pandoc/render-cache";
 import type { PandocEngineService } from "@/services/pandoc/service";
 
@@ -40,6 +45,7 @@ import {
 import type {
   ReferencesCopyBlock,
   ReferencesCopyState,
+  ReferencesCopyTarget,
   ReferencesFormatting,
   ReferencesListMode,
 } from "./store";
@@ -59,7 +65,7 @@ export interface ReferencesViewDeps {
     "getStatus" | "subscribe" | "decline"
   >;
   /** The plugin-wide render cache, which owns the Citation and References Style and the engine. */
-  bibliographyRender: Pick<BibliographyRenderCache, "render" | "on">;
+  bibliographyRender: Pick<BibliographyRenderCache, "renderAst" | "on">;
   /** Reveals the engine row in settings, where the install lives. */
   openSettings: () => void;
   /** Reveals the Citation and References Style row in settings. */
@@ -304,9 +310,15 @@ export class ReferencesView extends ItemView {
       formatting:
         this.#activeMarkdownPath() === path ? this.#formatting : "pending",
     });
+    // The list a snapshot is taken from stands for one note and one generation,
+    // and neither moves without a reload, so a snapshot already taken for the
+    // same pair is the same snapshot and the entries are shown once for it.
     this.#copySnapshot =
       copy.kind === "ready"
-        ? { ...copy.target, entries: copiedEntries(entries) }
+        ? (this.#heldSnapshot(copy.target) ?? {
+            ...copy.target,
+            entries: copiedEntries(entries),
+          })
         : null;
 
     const label = copy.kind === "ready" ? "ready" : copy.reason;
@@ -319,6 +331,14 @@ export class ReferencesView extends ItemView {
       });
     }
     return copy;
+  }
+
+  /** The snapshot already taken for `target`, when one was. */
+  #heldSnapshot(target: ReferencesCopyTarget): CopyBibliographySnapshot | null {
+    const held = this.#copySnapshot;
+    return held?.path === target.path && held.generation === target.generation
+      ? held
+      : null;
   }
 
   /**
@@ -357,7 +377,7 @@ export class ReferencesView extends ItemView {
     sources: ReadonlyMap<string, ReferenceSource>,
   ): Promise<void> {
     const items = [...sources.values()].map((source) => source.csl);
-    const outcome = await this.#deps.bibliographyRender.render(items);
+    const outcome = await this.#deps.bibliographyRender.renderAst(items);
     if (generation !== this.#generation) return;
 
     if (outcome.kind !== "rendered") {
@@ -420,11 +440,28 @@ export class ReferencesView extends ItemView {
   }
 }
 
-/** The completed entries of a ready list, in the style's bibliography order. */
+/**
+ * The completed entries of a ready list, in the style's bibliography order.
+ *
+ * The clipboard serializer still reads elements, so each entry is shown through
+ * the shared renderer once here and handed over as the DOM that render made.
+ */
 function copiedEntries(
   entries: readonly ReferenceEntry[],
 ): CopiedBibliographyEntry[] {
   return entries
     .filter((entry) => entry.kind === "rendered")
-    .map(({ marker, content }) => ({ marker, content }));
+    .map(({ marker, content }) => ({
+      marker: marker === undefined ? undefined : inlineText(marker),
+      content: entryFragment(content),
+    }));
+}
+
+/** One formatted entry as the DOM the shared renderer shows it in. */
+function entryFragment(content: Inlines): DocumentFragment {
+  const container = document.createElement("span");
+  renderInlineContent(container, { nodes: content });
+  const fragment = document.createDocumentFragment();
+  fragment.append(...container.childNodes);
+  return fragment;
 }

--- a/apps/obsidian/src/views/references/view.tsx
+++ b/apps/obsidian/src/views/references/view.tsx
@@ -23,11 +23,6 @@ import type {
 import type { CitationText } from "@/services/citation-text/service";
 import type { CitekeyEditor } from "@/services/citekey-editor/service";
 import type { DatabaseService } from "@/services/database/service";
-import type { Inlines } from "@/services/pandoc/ast";
-import {
-  inlineText,
-  renderInlineContent,
-} from "@/services/pandoc/inline-content";
 import type { BibliographyRenderCache } from "@/services/pandoc/render-cache";
 import type { PandocEngineService } from "@/services/pandoc/service";
 
@@ -499,25 +494,14 @@ export class ReferencesView extends ItemView {
 /**
  * The completed entries of a ready list, in the style's bibliography order.
  *
- * The clipboard serializer still reads elements, so each entry is shown through
- * the shared renderer once here and handed over as the DOM that render made.
+ * The clipboard serializer reads the formatted flows themselves, so an entry
+ * travels as the engine handed it over and is written for the destination once,
+ * at the copy.
  */
 function copiedEntries(
   entries: readonly ReferenceEntry[],
 ): CopiedBibliographyEntry[] {
   return entries
     .filter((entry) => entry.kind === "rendered")
-    .map(({ marker, content }) => ({
-      marker: marker === undefined ? undefined : inlineText(marker),
-      content: entryFragment(content),
-    }));
-}
-
-/** One formatted entry as the DOM the shared renderer shows it in. */
-function entryFragment(content: Inlines): DocumentFragment {
-  const container = document.createElement("span");
-  renderInlineContent(container, { nodes: content });
-  const fragment = document.createDocumentFragment();
-  fragment.append(...container.childNodes);
-  return fragment;
+    .map(({ marker, content }) => ({ marker, content }));
 }

--- a/apps/obsidian/src/views/references/view.tsx
+++ b/apps/obsidian/src/views/references/view.tsx
@@ -66,7 +66,7 @@ export interface ReferencesViewDeps {
     "getStatus" | "subscribe" | "decline"
   >;
   /** The plugin-wide render cache, which owns the Citation and References Style and the engine. */
-  bibliographyRender: Pick<BibliographyRenderCache, "renderAst" | "on">;
+  bibliographyRender: Pick<BibliographyRenderCache, "render" | "on">;
   /** Reveals the engine row in settings, where the install lives. */
   openSettings: () => void;
   /** Reveals the Citation and References Style row in settings. */
@@ -396,7 +396,7 @@ export class ReferencesView extends ItemView {
     sources: ReadonlyMap<string, ReferenceSource>,
   ): Promise<void> {
     const items = [...sources.values()].map((source) => source.csl);
-    const outcome = await this.#deps.bibliographyRender.renderAst(items);
+    const outcome = await this.#deps.bibliographyRender.render(items);
     if (generation !== this.#generation) return;
 
     if (outcome.kind !== "rendered") {

--- a/apps/obsidian/src/views/references/view.tsx
+++ b/apps/obsidian/src/views/references/view.tsx
@@ -1,6 +1,6 @@
 // ItemView orchestrator for the References Sidebar: reads the active document's Citations from the index and renders them through the Pandoc engine.
 import { ItemView } from "obsidian";
-import type { App, WorkspaceLeaf } from "obsidian";
+import type { App, TFile, WorkspaceLeaf } from "obsidian";
 import { createRoot } from "react-dom/client";
 import type { Root } from "react-dom/client";
 
@@ -20,6 +20,7 @@ import type {
   DocumentCitationSet,
   ReferenceSource,
 } from "@/services/citation-index/service";
+import type { CitationText } from "@/services/citation-text/service";
 import type { CitekeyEditor } from "@/services/citekey-editor/service";
 import type { DatabaseService } from "@/services/database/service";
 import type { Inlines } from "@/services/pandoc/ast";
@@ -60,6 +61,11 @@ export interface ReferencesViewDeps {
   citationIndex: Pick<CitationIndex, "getDocumentCitationSet" | "on">;
   /** Opens the Literature Note a citekey names, creating it first when it has none. */
   citekeyEditor: Pick<CitekeyEditor, "openCitekey">;
+  /**
+   * The active document's formatted citations, which say whether that document
+   * shows Entry Serials — the gutter follows what the citations show.
+   */
+  citationText: Pick<CitationText, "peek" | "load" | "on">;
   pandocEngine: Pick<
     PandocEngineService,
     "getStatus" | "subscribe" | "decline"
@@ -81,8 +87,13 @@ export class ReferencesView extends ItemView {
    * falls back to its summary mid-edit.
    */
   readonly #rendered = new Map<string, RenderedReference>();
-  /** Marker ownership of the last completed render for the current style. */
-  #listMode: ReferencesListMode = { kind: "minimal" };
+  /**
+   * Entry Marker ownership of the last completed render for the current style,
+   * or `null` while the list on screen is the minimal one.
+   */
+  #entryMarkers: boolean | null = null;
+  /** Whether the document's citations put this list's gutter on Entry Serials. */
+  #entrySerials = false;
   /** The current list is minimal because a completed formatting attempt failed. */
   #formattingFailed = false;
   #root: Root | null = null;
@@ -91,7 +102,9 @@ export class ReferencesView extends ItemView {
   #generation = 0;
   /** Bumped per rescan, the same way, since a query may await a file read. */
   #scan = 0;
-  /** Path of the Markdown note the current list was read from; `null` for none. */
+  /** The Markdown note the current list was read from; `null` for none. */
+  #file: TFile | null = null;
+  /** Path of that note, which is what a document-scoped event names. */
   #path: string | null = null;
   /** Citations of that note, as the current list was built from. */
   #citations: readonly Citation[] = [];
@@ -128,6 +141,7 @@ export class ReferencesView extends ItemView {
       app,
       db,
       citationIndex,
+      citationText,
       citekeyEditor,
       pandocEngine,
       bibliographyRender,
@@ -174,6 +188,13 @@ export class ReferencesView extends ItemView {
     this.register(citationIndex.on("resolution-changed", () => this.#rescan()));
     this.register(citationIndex.on("membership-changed", () => this.#rescan()));
     this.registerEvent(app.metadataCache.on("changed", () => this.#rescan()));
+    // What the document's own citations show decides what this gutter shows,
+    // so a fresh read of the note on screen republishes the list.
+    this.register(
+      citationText.on("changed", (path) => {
+        if (path === this.#path) this.#reload();
+      }),
+    );
     this.register(db.on("changed", () => this.#reload()));
     this.register(pandocEngine.subscribe(() => this.#reload()));
     // What the cache holds is what this pane shows, so its wholesale drop —
@@ -211,7 +232,8 @@ export class ReferencesView extends ItemView {
   #rescan(): void {
     const scan = ++this.#scan;
     this.#refreshCopy();
-    void this.#readCitationSet().then(({ path, citations, errors }) => {
+    void this.#readCitationSet().then(({ file, citations, errors }) => {
+      const path = file?.path ?? null;
       if (
         scan !== this.#scan ||
         (path === this.#path &&
@@ -220,6 +242,7 @@ export class ReferencesView extends ItemView {
       ) {
         return;
       }
+      this.#file = file;
       this.#path = path;
       this.#citations = citations;
       this.#errors = errors;
@@ -237,14 +260,14 @@ export class ReferencesView extends ItemView {
    * active note moves while the read runs.
    */
   async #readCitationSet(): Promise<
-    DocumentCitationSet & { path: string | null }
+    DocumentCitationSet & { file: TFile | null }
   > {
     const file = this.#deps.app.workspace.getActiveFile();
     if (!file || file.extension !== "md") {
-      return { path: null, occurrences: [], citations: [], errors: [] };
+      return { file: null, occurrences: [], citations: [], errors: [] };
     }
     return {
-      path: file.path,
+      file,
       ...(await this.#deps.citationIndex.getDocumentCitationSet(file)),
     };
   }
@@ -257,9 +280,10 @@ export class ReferencesView extends ItemView {
   #reload({ invalidate = false } = {}): void {
     if (invalidate) {
       this.#rendered.clear();
-      this.#listMode = { kind: "minimal" };
+      this.#entryMarkers = null;
       this.#formattingFailed = false;
     }
+    this.#entrySerials = this.#readEntrySerials();
     const generation = ++this.#generation;
     const citations = this.#citations;
     const { sources } = readReferenceSources(this.#deps.db, citations);
@@ -277,7 +301,7 @@ export class ReferencesView extends ItemView {
     this.#formatting = engine.kind === "installed" ? "pending" : "unavailable";
     this.#store.setState({
       entries,
-      listMode: this.#listMode,
+      listMode: this.#listMode(),
       engine,
       formattingFailed: this.#formattingFailed,
       dbReady: this.#deps.db.state === "ready",
@@ -392,10 +416,7 @@ export class ReferencesView extends ItemView {
     for (const { id, marker, content } of outcome.entries) {
       this.#rendered.set(id, { marker, content });
     }
-    this.#listMode = {
-      kind: "bibliography",
-      hasEntryMarkers: outcome.hasEntryMarkers,
-    };
+    this.#entryMarkers = outcome.hasEntryMarkers;
     this.#formattingFailed = false;
     this.#formatting = "complete";
     logger.debug("References bibliography rendered", {
@@ -411,10 +432,45 @@ export class ReferencesView extends ItemView {
     });
     this.#store.setState({
       entries,
-      listMode: this.#listMode,
+      listMode: this.#listMode(),
       formattingFailed: false,
       copy: this.#trackCopy(entries),
     });
+  }
+
+  /**
+   * Which list is on screen, and what its gutter carries.
+   *
+   * The two answers are read apart — a completed render says whether the style
+   * writes Entry Markers, the document's own citations say whether they show
+   * Entry Serials — and either can settle first, so the mode is composed as it
+   * is published rather than held.
+   */
+  #listMode(): ReferencesListMode {
+    return this.#entryMarkers === null
+      ? { kind: "minimal" }
+      : {
+          kind: "bibliography",
+          hasEntryMarkers: this.#entryMarkers,
+          entrySerials: this.#entrySerials,
+        };
+  }
+
+  /**
+   * Whether the note this list answers for shows Entry Serials.
+   *
+   * The answer is the held citation text of that note — the very text its own
+   * surfaces show — so the digits in this gutter are the digits those surfaces
+   * print. A note nothing has read yet is read now, and that read announces
+   * itself when it settles.
+   */
+  #readEntrySerials(): boolean {
+    const file = this.#file;
+    if (file === null) return false;
+    const held = this.#deps.citationText.peek(file.path);
+    if (held !== null) return held.entrySerials;
+    void this.#deps.citationText.load(file);
+    return false;
   }
 
   /** Replace stale formatted entries with the current minimal reference list. */
@@ -424,7 +480,7 @@ export class ReferencesView extends ItemView {
     formattingFailed: boolean,
   ): void {
     this.#rendered.clear();
-    this.#listMode = { kind: "minimal" };
+    this.#entryMarkers = null;
     this.#formattingFailed = formattingFailed;
     this.#formatting = formattingFailed ? "failed" : "unavailable";
     const minimal = minimalReferencesState({

--- a/apps/obsidian/src/zt-main.ts
+++ b/apps/obsidian/src/zt-main.ts
@@ -275,6 +275,7 @@ export default class ZotLitPlugin extends Plugin {
       app: this.app,
       db: services.db,
       citationIndex: services.citationIndex,
+      citationText: services.citationText,
       citekeyEditor: services.citekeyEditor,
       pandocEngine: services.pandocEngine,
       bibliographyRender: services.bibliographyRender,


### PR DESCRIPTION
Part of #754.

This PR carries the full spec #754 chain: it moves ZotLit's Pandoc-to-DOM path from HTML string parsing to a typed AST boundary, threads that AST through every in-text and sidebar surface, and finishes by deleting the retired HTML parse path.

## #755 — Engine: typed AST boundary, expand step

Implements #755 (typed AST engine boundary, expand step). Added `apps/obsidian/src/services/pandoc/ast.ts` — the pandoc-types 1.23 JSON encoding as types only (20 Inline + 14 Block constructors with table payloads, Citation, Attr, Target, tag enums, Meta, Pandoc envelope; all readonly, zero runtime code). Extended the engine with `renderBibliographyAst` / `renderCitationsAst` beside the untouched HTML methods, sharing option building through new private `#formatBibliography`/`#formatCitations` helpers that differ only in the pandoc writer. New domain shapes `AstBibliographyEntry`, `RenderedCitation`, `CitedWork`, `CitationMode`; the Pandoc envelope is unwrapped inside the engine and never crosses the boundary. Bibliography extraction keeps the Entry Marker split without the layout space and passes other `csl-*` spans through; citation extraction aligns positionally, decodes citationMode, drops hash/note-num/prefix/suffix, and raises `CitationEngineError` on a count mismatch. The render cache gained `renderAst` / `renderCitationsAst` holding typed renders in their own bounded caches, returning reference-identical values and dropped by the same invalidation signals (`#clearHeld` covers all four caches); `BibliographyRenderResult`/`Outcome` gained an entry type parameter defaulting to the HTML entry so existing consumers are unchanged.

Tests: engine integration suite (real pandoc WASM) now covers typed entry ids incl. Zotero-URI ids, marker/content split as inlines, display spans passed through, citation count/order fidelity, prefix/locator/author-suppression, numbered styles, the `CitationEngineError` path, and a new note-class style fixture yielding Note-bearing content with author inlines beside the Note for author-in-text; render-cache tests pin shared-immutable identity and invalidation. Full suite green (1933 tests, 112 files), lint and format clean.

## #756 — Shared inline renderer + detached-render adapter

Implemented issue #756 (shared inline renderer + detached-render adapter). New files:
- `apps/obsidian/src/services/pandoc/inline-content.tsx` — the shared component `InlineContent` (props: nodes, serials?, links? defaulting to "render") plus the adapter `renderInlineContent(container, props)`. Covers Emph/Strong/Underline/Strikeout/Superscript/Subscript, SmallCaps as a `zt:[font-variant:small-caps]` span, Quoted as literal quote characters, Str/Space/SoftBreak/LineBreak. Cite is transparent; AST attrs never reach the DOM; Math degrades to its TeX source, Code to `<code>`, Image to its alt inlines; RawInline drops with a debug log. Display spans (csl-block, csl-indent, csl-left-margin, csl-right-inline) flatten with a single-space join at boundaries; nocase/nodecoration/class-less/unknown spans render children only. Links become bare anchors for http:/https:/mailto: with title as aria-label; fragment, relative, and disallowed schemes render children only, as does links="suppress". A Note renders one `<sup class="zt-entry-serial">` with comma-separated digits and ⚠ for empty slots; with no serial context it drops with a debug log.
- `apps/obsidian/src/services/pandoc/inline-content.test.ts` — 34 tests (happy-dom + Preact) covering the vocabulary table, degradation policies, span flattening, the link allow-list and suppression, serial presentation, and the adapter.

Also registered the `entrySerial: "zt-entry-serial"` theme hook and documented it.

Verification: `pnpm lint` clean, typecheck clean, full obsidian suite green (113 files, 1967 tests), plugin build succeeds.

Fix-pass findings addressed:
- The detached adapter now asserts synchronous population (`container.hasChildNodes()`), logging at `error` when a deferred commit leaves the container empty in production — refined so a legitimately-empty render (e.g. an all-dropped flow) still passes silently.
- Suppressed links now render children as plain text (formatting stripped), distinct from the disallowed-target arm which keeps children's own formatting — matching spec #754 and ticket #756 wording.
- Tooltips now go through the shared `tooltipAttrs` helper instead of a direct `aria-label` attribute.

## #757 — References Sidebar renders from AST

Implemented #757 "References Sidebar renders from AST".
- `apps/obsidian/src/views/references/entries.ts` — `RenderedReference` now carries typed AST (`marker: Inlines | undefined`, `content: Inlines`) instead of a marker string and a DocumentFragment.
- `apps/obsidian/src/views/references/References.tsx` — a rendered entry and its Entry Marker both show through the shared `InlineContent` component; the `RenderedEntry`/`useDomContent` cloning wrapper is gone; `referencePresentation.gutter` is now a ReactNode.
- `apps/obsidian/src/views/references/view.tsx` — reads `bibliographyRender.renderAst` instead of `render`.
- `apps/obsidian/src/services/pandoc/inline-content.tsx` — added the exported `inlineText(nodes)` inline-stringify helper.
- `apps/obsidian/src/lib/sanitize-html.ts` — deleted `useDomContent`, orphaned by this change (`useSanitizedHtml` stays for the annotation view).
- Tests moved to AST fixtures across `entries.test.ts`, `store.test.ts`, `References.test.ts`, `view.test.ts`, `document-citation-set.integration.test.ts`.

Verification: `pnpm lint` clean, `pnpm format` clean, `pnpm test` green (113 files, 1970 tests).

Two decisions flagged for review: Copied Bibliography (#761) still runs on innerHTML-built fragments as an interim state (small-caps styling loss, accepted until #761 landed); `#trackCopy` reuses the snapshot already taken for the same note/generation to bound render cost.

## #758 — Reading view and Live Preview render from AST

Implemented "Reading view and Live Preview render from AST".
- `services/citation-text/present.ts`: `DocumentCitations.formatted` now holds `RenderedCitation` AST values instead of `DocumentFragment`; clone-on-insert helper replaced by `showCitation(element, content, links)` using the shared renderer's detached adapter.
- `services/citation-text/service.ts`: reads `renderCitationsAst` from the render cache.
- `services/wikilink-reading/render.ts` + `service.ts`: `FormatWikilinkRun` returns `RenderedCitation | null`; the run's Obsidian anchor is filled with `links: "suppress"`.
- `services/citekey-editor/extension.ts`: `CitationWidget` holds a `RenderedCitation`; `eq` is an O(1) reference test.
- `services/wikilink-editor/extension.ts`: `CitationDisplayWidget` holds a `RenderedCitation`, renders with `links: "suppress"`.

Tests: citation-text fixtures moved from fragments to AST; added a `citationElement` renderer test, a citekey-editor test pinning that a distant edit keeps the exact drawn element, and one test per wikilink surface pinning link nodes render as plain text.

Left to later tickets per spec sequencing: serials wiring (#760), occurrence keying (#759), HTML parse-path deletion (#762) — kept alive for the clipboard ticket (#761).

Verification: `pnpm lint` clean, `pnpm format`, `pnpm test` green (1975 tests, 113 files).

Fix-pass findings addressed: added a wikilink-editor test pinning that the drawn citation element survives an edit landing away from it (mutation-checked against `eq`); simplified a test's EditorView setup to reuse the shared `editorView()` helper; called out (not fixed, correctly deferred to #762) that the render-cache's DocumentFragment path removal belongs to the contract ticket.

## #759 — Document Citation Text keyed by Citation Occurrence

Implemented #759 — Document Citation Text is now keyed by Citation Occurrence instead of by source text.
- `services/citation-text/present.ts`: `DocumentCitations.formatted` is now `ReadonlyMap<string, readonly FormattedOccurrence[]>` — every occurrence of one identity, in document order, each at the offset the document writes it at. Added `CitationCoordinate` (exact offset, or section range plus ordinal), an optional `at` parameter on `citationContent`, and `sectionCoordinates()`.
- `services/citation-text/service.ts`: collects one occurrence per rendered citation instead of collapsing to the first answer.
- `lib/reading-view.ts`: new `sectionRange(ctx, el)` plus `SectionRange`, converting `getSectionInfo`'s line range into document offsets.
- Live Preview (`citekey-editor`, `wikilink-editor`) and reading view (`citekey-reading`, `wikilink-reading`) now pass/match on document offset or section ordinal.
- One rule for misses: no coordinate, a stale offset, or an unplaceable section falls back to the source's first-occurrence text, never to nothing.

Tests added across `pandoc/engine.test.ts` (new position-dependent CSL fixture), `citation-text/service.test.ts`, `citation-text/present.test.ts`, `citekey-editor/extension.test.ts`, `citekey-reading/service.test.ts`.

Verification: `pnpm lint` clean, `pnpm format` clean, obsidian test 113 files / 1986 tests green.

Fix-pass findings addressed: rewrote `CitationText` class doc to state occurrence keying accurately instead of a stale "read alike" claim (satisfies acceptance criterion 4 of #759); dropped the same retired claim from `citation-fragment.ts`; made the debug-log properties lazy so the occurrence-map reduce only runs when debug logging is enabled; added a missing `@param ctx` JSDoc tag; renamed a test fixture helper for accuracy and tightened two default-parameter fallbacks.

## #760 — Entry Serial fallback and gutter agreement

Implemented #760 (Entry Serial fallback and gutter agreement).
- `services/pandoc/inline-content.tsx` — new exported `holdsNote(nodes)`.
- `services/citation-text/present.ts` — new `PresentedCitation` (`{ text, serials }`); `FormattedOccurrence` extends it; `DocumentCitations` gains `entrySerials`.
- `services/citation-text/service.ts` — serials precomputed once per read: output-derived (`rendered.some(holdsNote)`), then mapped from item identity to 1-based place to the Indexed Key each citation names the work by. A work with no row keeps an empty slot (renderer draws ⚠).
- Four in-text surfaces (citekey/wikilink × reading/editor) forward the presented value.
- References Sidebar — each formatted entry gets a `serial`; `store.ts` list mode gains `entrySerials`; `References.tsx` opens the gutter for serials; `view.tsx` reads/republishes `entrySerials`.

Tests: acceptance test for #735 on real pandoc WASM with a note-class style; `citation-text/service.test.ts`, `entries.test.ts`, `References.test.ts`, `view.test.ts`, `inline-content.test.ts` all green (113 files / 1998 tests, lint and format clean).

Note for reviewers carried over: inline serials and the gutter agree by construction because both derive from the same cached bibliography render. Copied Bibliography still passes no serials.

## #761 — Copied Bibliography serializes from typed AST

Implemented #761: the Copied Bibliography now serializes directly from `BibliographyEntry` AST values. `copied-bibliography.ts` takes `Inlines` for marker and content, writes rich HTML with one walk over `Inline[]` and plain text through `inlineText` plus the existing whitespace collapsing; the DOM-rebuild walk over cloned fragments and `view.tsx`'s `entryFragment` detached render are deleted. `inline-content.tsx` exports the shared tables the serializer reuses verbatim (`WRAPPER_TAGS`, `QUOTE_MARKS`, `DISPLAY_CLASSES`, `linkHref`).

Strikeout reaches the clipboard as `<del>`, a disallowed scheme or relative target loses its anchor and keeps its text, a Note carries no Entry Serial, and small caps rides as inline style again (the old path copied it off a Tailwind class that carried no inline style, so the semantic was being lost). Clipboard suite rebuilt on AST fixtures. `pnpm test` for `@zotlit/obsidian` passes (113 files, 2002 tests, typecheck included); lint and format clean.

Fix-pass findings addressed: extracted the shared separator state machine into one exported helper `flowWriter<T>(append)` consumed by both `renderFlow()` and the serializer's `portable()`, removing the duplicated block; tightened `WRAPPER_TAGS` and `richEntry()` doc comments to claim only what holds; confirmed the non-ASCII spacing test coverage was never lost (a false-positive diff read); left the docs strikethrough update in place as in-scope per #761's acceptance criteria.

## #762 — Contract: delete the HTML parse path

Implemented #762 ("Contract: delete the HTML parse path"), the contract step of spec #754.
- `services/pandoc/engine.ts` — deleted the HTML path: `sanitizeHTMLToDom` import, `parseCitations`, `parseBibliography`, the DOM `splitEntry` flatten apparatus with `hasClass`/`isWhitespace`, and `ENTRY_BLOCK_CLASSES`. The AST members lost their `Ast` disambiguators (`AstBibliographyEntry` → `BibliographyEntry`, `renderBibliographyAst`/`renderCitationsAst` → `renderBibliography`/`renderCitations`, `splitAstEntry` → `splitEntry`). `#formatBibliography`/`#formatCitations` now ask Pandoc for `to: "json"` only.
- `services/pandoc/render-cache.ts` — one bibliography cache and one citation cache instead of four; renamed accordingly; `BibliographyRenderResult`/`Outcome` no longer generic over the entry type.
- Consumers renamed: `citation-text/service.ts`, `views/references/view.tsx`.
- Tests: `engine.test.ts` dropped the HTML assertions and the now-orphaned `NESTED_BLOCK_STYLE` fixture; `render-cache.test.ts` dropped the fragment stub/fixtures and the duplicate describe block. Both files no longer need `happy-dom`.

Verification: `pnpm quality` clean (oxlint 0 warnings/errors, oxfmt clean), `tsc` clean for both app and test projects, `pnpm test` green — 113 files / 1983 tests.

## Spec review

Whole-branch review against spec #754 (standards + spec axes) passed clean on the first pass, so no fix was needed.

---

Implements #755
Implements #756
Implements #757
Implements #758
Implements #759
Implements #760
Implements #761
Implements #762
Part of #754
